### PR TITLE
Refactor: Improve readability on FilterMenu title mapping

### DIFF
--- a/src/feature/movies/src/commonMain/kotlin/com/gabrielbmoro/moviedb/movies/ui/widgets/FilterMenu.kt
+++ b/src/feature/movies/src/commonMain/kotlin/com/gabrielbmoro/moviedb/movies/ui/widgets/FilterMenu.kt
@@ -36,12 +36,14 @@ fun FilterMenu(
             FilterChip(
                 selected = menuItem.selected,
                 label = {
-                    val menuTitle = when (menuItem.type) {
-                        FilterType.NowPlaying -> stringResource(Res.string.now_playing)
-                        FilterType.TopRated -> stringResource(Res.string.top_rated)
-                        FilterType.Popular -> stringResource(Res.string.popular)
-                        FilterType.UpComing -> stringResource(Res.string.upcoming)
-                    }
+                    val menuTitle = stringResource(
+                        when (menuItem.type) {
+                            FilterType.NowPlaying -> Res.string.now_playing
+                            FilterType.TopRated -> Res.string.top_rated
+                            FilterType.Popular -> Res.string.popular
+                            FilterType.UpComing -> Res.string.upcoming
+                        }
+                    )
                     Text(menuTitle)
                 },
                 onClick = {


### PR DESCRIPTION
# Pull Request Title
Refactor: Improve readability on FilterMenu title mapping

## Description 📑
The code was refactored to use a `when` statement directly within the `stringResource` function call for mapping `FilterType` to string resources. This change enhances code readability by reducing verbosity.

## Evidence:

https://github.com/user-attachments/assets/1cf5349c-2083-4f0f-8b3a-1b62912b87b2

