### PR TITLE
Enhancement: refactor modifier in filter menu

### DIFF
--- a/src/feature/movies/src/commonMain/kotlin/com/gabrielbmoro/moviedb/movies/ui/widgets/FilterMenu.kt
+++ b/src/feature/movies/src/commonMain/kotlin/com/gabrielbmoro/moviedb/movies/ui/widgets/FilterMenu.kt
@@ -25,7 +25,7 @@ fun FilterMenu(
     modifier: Modifier = Modifier
 ) {
     LazyRow(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         contentPadding = PaddingValues(vertical = 8.dp)
     ) {

--- a/src/feature/movies/src/commonMain/kotlin/com/gabrielbmoro/moviedb/movies/ui/widgets/FilterMenu.kt
+++ b/src/feature/movies/src/commonMain/kotlin/com/gabrielbmoro/moviedb/movies/ui/widgets/FilterMenu.kt
@@ -2,7 +2,6 @@ package com.gabrielbmoro.moviedb.movies.ui.widgets
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Text


### PR DESCRIPTION
# Pull Request Title
Enhancement: refactor modifier in filter menu

## Description 📑

The `fillMaxWidth` modifier was removed from the `LazyRow` in `FilterMenu`. This change allows the `LazyRow` to size itself based on content or parent modification, rather than always expanding to fill the available width. Besides, the `fillMaxWidth` is already applied [here](https://github.com/gabrielbmoro/MovieDB-App/blob/48bfe03ff1994849da514591df9e7c0088f92ecd/src/feature/movies/src/commonMain/kotlin/com/gabrielbmoro/moviedb/movies/ui/screens/movies/MoviesScreen.kt#L91)

## Evidence


https://github.com/user-attachments/assets/fdf374e1-c95a-4009-95c2-0f16d96c7865

