### PR TITLE
Refactor MoviesScreen to use method reference for navigateToWishlist

### DIFF
--- a/src/feature/movies/src/commonMain/kotlin/com/gabrielbmoro/moviedb/movies/ui/screens/movies/MoviesScreen.kt
+++ b/src/feature/movies/src/commonMain/kotlin/com/gabrielbmoro/moviedb/movies/ui/screens/movies/MoviesScreen.kt
@@ -71,9 +71,7 @@ fun MoviesScreen(
                         lazyStaggeredGridState.scrollToItem(0)
                     }
                 },
-                onSelectFavoriteTab = {
-                    navigator.navigateToWishlist()
-                }
+                onSelectFavoriteTab = navigator::navigateToWishlist
             )
         }
     ) {


### PR DESCRIPTION
# Pull Request Title
Refactor `MoviesScreen` to use method reference for `navigateToWishlist`

## Description 📑
The `onSelectFavoriteTab` lambda on the `MoviesTopBar` was refactored from an anonymous lambda to a method reference, improving code conciseness by directly referencing the `navigator::navigateToWishlist` function.

## Screenshots or Videos 📸

https://github.com/user-attachments/assets/94f4a332-6692-4853-92cb-649e9fe47fe0

