### PR TITLE
Fix the dark theme not being applied automatically in iOS

### DIFF
--- a/src/composeApp/src/iosMain/kotlin/com/gabrielbmoro/moviedb/MainViewController.kt
+++ b/src/composeApp/src/iosMain/kotlin/com/gabrielbmoro/moviedb/MainViewController.kt
@@ -1,6 +1,9 @@
 import androidx.compose.ui.window.ComposeUIViewController
+import com.gabrielbmoro.moviedb.desingsystem.theme.MovieDBAppTheme
 
 @Suppress("FunctionNaming")
 fun MainViewController() = ComposeUIViewController {
-    RootApp()
+    MovieDBAppTheme {
+        RootApp()
+    }
 }


### PR DESCRIPTION
# Pull Request Title
Fix the dark theme not being applied automatically in iOS.

## Description 📑
Wrap the iOS app in the MovieDBAppTheme to apply the design system.

## Issues 🔖
- Issue 175 -> https://github.com/gabrielbmoro/MovieDB-App/issues/175

## Screenshots or Videos 📸

https://github.com/user-attachments/assets/af5c488b-c500-4ad4-9e39-dbf3e52b91ad



