### PR TITLE
Refactor: Replace sealed class with sealed interface for intents

### DIFF
--- a/src/feature/details/src/commonMain/kotlin/com/gabrielbmoro/moviedb/details/ui/screens/details/Model.kt
+++ b/src/feature/details/src/commonMain/kotlin/com/gabrielbmoro/moviedb/details/ui/screens/details/Model.kt
@@ -2,14 +2,14 @@ package com.gabrielbmoro.moviedb.details.ui.screens.details
 
 import kotlinx.collections.immutable.ImmutableList
 
-sealed class DetailsUserIntent {
-    data object HideVideo : DetailsUserIntent()
+sealed interface DetailsUserIntent {
+    data object HideVideo : DetailsUserIntent
 
-    data object FavoriteMovie : DetailsUserIntent()
+    data object FavoriteMovie : DetailsUserIntent
 
     data class LoadMovieDetails(
         val movieId: Long
-    ): DetailsUserIntent()
+    ): DetailsUserIntent
 }
 
 data class DetailsUIState(

--- a/src/feature/search/src/commonMain/kotlin/com/gabrielbmoro/moviedb/search/ui/screens/search/Model.kt
+++ b/src/feature/search/src/commonMain/kotlin/com/gabrielbmoro/moviedb/search/ui/screens/search/Model.kt
@@ -4,10 +4,10 @@ import androidx.compose.ui.text.input.TextFieldValue
 import com.gabrielbmoro.moviedb.search.ui.widgets.MovieCardInfo
 import kotlinx.collections.immutable.ImmutableList
 
-sealed class SearchUserIntent {
-    data class SearchBy(val query: TextFieldValue) : SearchUserIntent()
+sealed interface SearchUserIntent {
+    data class SearchBy(val query: TextFieldValue) : SearchUserIntent
 
-    data object ClearSearchField : SearchUserIntent()
+    data object ClearSearchField : SearchUserIntent
 }
 
 data class SearchUIState(

--- a/src/feature/wishlist/src/commonMain/kotlin/com/gabrielbmoro/moviedb/wishlist/ui/screens/wishlist/Model.kt
+++ b/src/feature/wishlist/src/commonMain/kotlin/com/gabrielbmoro/moviedb/wishlist/ui/screens/wishlist/Model.kt
@@ -3,16 +3,16 @@ package com.gabrielbmoro.moviedb.wishlist.ui.screens.wishlist
 import com.gabrielbmoro.moviedb.wishlist.ui.widgets.MovieCardInfo
 import kotlinx.collections.immutable.ImmutableList
 
-sealed class WishlistUserIntent {
-    data class PrepareToDeleteMovie(val movie: MovieCardInfo) : WishlistUserIntent()
+sealed interface WishlistUserIntent {
+    data class PrepareToDeleteMovie(val movie: MovieCardInfo) : WishlistUserIntent
 
-    data object DeleteMovie : WishlistUserIntent()
+    data object DeleteMovie : WishlistUserIntent
 
-    data object LoadMovies : WishlistUserIntent()
+    data object LoadMovies : WishlistUserIntent
 
-    data object ResultMessageReset : WishlistUserIntent()
+    data object ResultMessageReset : WishlistUserIntent
 
-    data object HideConfirmDeleteDialog : WishlistUserIntent()
+    data object HideConfirmDeleteDialog : WishlistUserIntent
 }
 
 data class WishlistUIState(


### PR DESCRIPTION
# Pull Request Title
Refactor: Replace sealed class with sealed interface for intents

## Description 📑
Same as https://github.com/gabrielbmoro/MovieDB-App/pull/271 but for the other missing intents.
Replaced `sealed class` with `sealed interface` for `UserIntent` types in the details, search, and wishlist modules to leverage the benefits of sealed interfaces, allowing for more flexible inheritance and module separation.
