### PR TITLE
Refactor: Use orEmpty() instead of elvis operator for string properties

### DIFF
--- a/src/data/src/commonMain/kotlin/com/gabrielbmoro/moviedb/data/repository/ResponseMappers.kt
+++ b/src/data/src/commonMain/kotlin/com/gabrielbmoro/moviedb/data/repository/ResponseMappers.kt
@@ -14,7 +14,7 @@ fun MovieResponse.toMovie(): Movie {
     return Movie(
         id = id,
         votesAverage = vote_average ?: 0f,
-        title = title ?: "",
+        title = title.orEmpty(),
         posterImageUrl = poster_path?.let { SMALL_SIZE_IMAGE_ADDRESS.plus(it) },
         backdropImageUrl =
         backdrop_path?.let {
@@ -22,10 +22,10 @@ fun MovieResponse.toMovie(): Movie {
                 backdrop_path
             )
         },
-        overview = overview ?: "",
-        releaseDate = release_date ?: "",
+        overview = overview.orEmpty(),
+        releaseDate = release_date.orEmpty(),
         popularity = popularity ?: 0f,
-        language = original_language ?: "",
+        language = original_language.orEmpty(),
         isFavorite = false
     )
 }
@@ -41,7 +41,7 @@ fun MovieDetailResponse.toMovieDetail(): MovieDetail {
         tagline = tagline,
         productionCompanies = production_companies.map { it.name },
         votesAverage = vote_average ?: 0f,
-        title = title ?: "",
+        title = title.orEmpty(),
         posterImageUrl = poster_path?.let { SMALL_SIZE_IMAGE_ADDRESS.plus(it) },
         backdropImageUrl =
         backdrop_path?.let {
@@ -49,10 +49,10 @@ fun MovieDetailResponse.toMovieDetail(): MovieDetail {
                 backdrop_path
             )
         },
-        overview = overview ?: "",
-        releaseDate = release_date ?: "",
+        overview = overview.orEmpty(),
+        releaseDate = release_date.orEmpty(),
         popularity = popularity ?: 0f,
-        language = original_language ?: ""
+        language = original_language.orEmpty(),
     )
 }
 

--- a/src/feature/movies/src/commonMain/kotlin/com/gabrielbmoro/moviedb/movies/ui/screens/movies/MoviesViewModel.kt
+++ b/src/feature/movies/src/commonMain/kotlin/com/gabrielbmoro/moviedb/movies/ui/screens/movies/MoviesViewModel.kt
@@ -138,7 +138,7 @@ class MoviesViewModel(
     private fun toMovieCardInfo(movie: Movie) = MovieCardInfo(
         movieId = movie.id,
         movieTitle = movie.title,
-        moviePosterUrl = movie.posterImageUrl ?: ""
+        moviePosterUrl = movie.posterImageUrl.orEmpty(),
     )
 
     private fun defaultEmptyState() =

--- a/src/feature/search/src/commonMain/kotlin/com/gabrielbmoro/moviedb/search/ui/screens/search/SearchViewModel.kt
+++ b/src/feature/search/src/commonMain/kotlin/com/gabrielbmoro/moviedb/search/ui/screens/search/SearchViewModel.kt
@@ -87,7 +87,7 @@ class SearchViewModel(
         return MovieCardInfo(
             movieId = movie.id,
             movieTitle = movie.title,
-            moviePosterImageUrl = movie.posterImageUrl ?: "",
+            moviePosterImageUrl = movie.posterImageUrl.orEmpty(),
             movieOverview = movie.overview,
             movieVotesAverage = movie.votesAverage,
         )


### PR DESCRIPTION
# Pull Request Title
Refactor: Use `orEmpty()` instead of elvis operator for string properties

## Description 📑
The changes replace the elvis operator + `""` with the `orEmpty()` method when handling nullable strings in `SearchViewModel`, `MoviesViewModel`, and `ResponseMappers`.
