### PR TITLE
Refactor: image address constants to use a base URL

### DIFF
--- a/src/data/src/commonMain/kotlin/com/gabrielbmoro/moviedb/data/repository/ResponseMappers.kt
+++ b/src/data/src/commonMain/kotlin/com/gabrielbmoro/moviedb/data/repository/ResponseMappers.kt
@@ -7,8 +7,9 @@ import com.gabrielbmoro.moviedb.domain.entities.Movie
 import com.gabrielbmoro.moviedb.domain.entities.MovieDetail
 import com.gabrielbmoro.moviedb.domain.entities.VideoStream
 
-const val BIG_SIZE_IMAGE_ADDRESS = "https://image.tmdb.org/t/p/w780"
-const val SMALL_SIZE_IMAGE_ADDRESS = "https://image.tmdb.org/t/p/w300"
+private const val BASE_URL = "https://image.tmdb.org/t/p/w"
+const val BIG_SIZE_IMAGE_ADDRESS = "${BASE_URL}780"
+const val SMALL_SIZE_IMAGE_ADDRESS = "${BASE_URL}300"
 
 fun MovieResponse.toMovie(): Movie {
     return Movie(


### PR DESCRIPTION
# Pull Request Title
Refactor image address constants to use a base URL 

## Evidence:


https://github.com/user-attachments/assets/8af975da-aa0a-4317-9c5b-8f780a170468

