### PR TITLE
Rename `AppToolbar` to `AppToolbarTitle` and refactor navigation icon logic

### DIFF
--- a/src/designsystem/src/commonMain/kotlin/com/gabrielbmoro/moviedb/desingsystem/toolbars/AppToolbarTitle.kt
+++ b/src/designsystem/src/commonMain/kotlin/com/gabrielbmoro/moviedb/desingsystem/toolbars/AppToolbarTitle.kt
@@ -17,15 +17,6 @@ fun AppToolbarTitle(
     backEvent: (() -> Unit)? = null,
     searchEvent: (() -> Unit)? = null
 ) {
-    val backNavigationIcon: @Composable (() -> Unit) =
-        if (backEvent != null) {
-            {
-                BackNavigationIcon(backEvent)
-            }
-        } else {
-            {}
-        }
-
     TopAppBar(
         title = {
             Text(
@@ -34,7 +25,9 @@ fun AppToolbarTitle(
                 overflow = TextOverflow.Ellipsis
             )
         },
-        navigationIcon = backNavigationIcon,
+        navigationIcon = {
+            backEvent?.let { BackNavigationIcon(it) }
+        },
         colors =
         TopAppBarDefaults.topAppBarColors(
             containerColor = MaterialTheme.colorScheme.primaryContainer


### PR DESCRIPTION
## Description
Rename `AppToolbar` file to `AppToolbarTitle` (to be as same as composable name) and refactor navigation icon logic

## Evidence

https://github.com/user-attachments/assets/594d9c66-7634-404b-96a4-8adb31b263d0

