### PR TITLE
Fix: Handle empty production companies list when reducing to text

### DIFF
--- a/src/feature/details/src/commonMain/kotlin/com/gabrielbmoro/moviedb/details/ui/screens/details/DetailsViewModel.kt
+++ b/src/feature/details/src/commonMain/kotlin/com/gabrielbmoro/moviedb/details/ui/screens/details/DetailsViewModel.kt
@@ -99,7 +99,10 @@ class DetailsViewModel(
                     status = movieDetails.status,
                     genres = movieDetails.genres.toImmutableList(),
                     homepage = movieDetails.homepage,
-                    productionCompanies = movieDetails.productionCompanies.reduceToText(),
+                    productionCompanies = movieDetails
+                        .productionCompanies.takeIf { productionCompanies ->
+                            productionCompanies.isNotEmpty()
+                        }?.reduceToText(),
                     movieTitle = movieDetails.title,
                     movieOverview = movieDetails.overview,
                     movieLanguage = movieDetails.language,


### PR DESCRIPTION
## Description 📑

The change introduces a check for an empty list of `productionCompanies` before attempting to reduce it to a text representation. This prevents potential issues when the list is empty. The `takeIf` function is used to conditionally perform the reduction only when the list is not empty.

---

Closes #301 

---

## Evidence 📸

| Before | After |
| -- | -- |
| <video width="250" src="https://github.com/user-attachments/assets/7dd7586b-2f55-493b-a0c1-3bba5acd5614" /> | <video width="250" src="https://github.com/user-attachments/assets/9db56c2c-d26a-4076-9202-aeed6c2d82ac" /> |




