### PR TITLE
Refactor: Update FilterMenu to use items instead of count and index

### DIFF
--- a/src/feature/movies/src/commonMain/kotlin/com/gabrielbmoro/moviedb/movies/ui/widgets/FilterMenu.kt
+++ b/src/feature/movies/src/commonMain/kotlin/com/gabrielbmoro/moviedb/movies/ui/widgets/FilterMenu.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,37 +18,27 @@ import moviedbapp.feature.movies.generated.resources.now_playing
 import moviedbapp.feature.movies.generated.resources.popular
 import moviedbapp.feature.movies.generated.resources.top_rated
 import moviedbapp.feature.movies.generated.resources.upcoming
+import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun FilterMenu(
     menuItems: List<FilterMenuItem>,
-    onClick: (FilterMenuItem) -> Unit,
     lazyListState: LazyListState,
-    modifier: Modifier = Modifier
+    onClick: (FilterMenuItem) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     LazyRow(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         contentPadding = PaddingValues(vertical = 8.dp),
         state = lazyListState,
     ) {
-        items(
-            count = menuItems.size
-        ) { index ->
-            val menuItem = menuItems[index]
+        items(menuItems) { menuItem ->
             FilterChip(
                 selected = menuItem.selected,
                 label = {
-                    val menuTitle = stringResource(
-                        when (menuItem.type) {
-                            FilterType.NowPlaying -> Res.string.now_playing
-                            FilterType.TopRated -> Res.string.top_rated
-                            FilterType.Popular -> Res.string.popular
-                            FilterType.UpComing -> Res.string.upcoming
-                        }
-                    )
-                    Text(menuTitle)
+                    Text(stringResource(menuItem.toStringResource()))
                 },
                 onClick = {
                     onClick(menuItem)
@@ -55,4 +46,11 @@ fun FilterMenu(
             )
         }
     }
+}
+
+private fun FilterMenuItem.toStringResource(): StringResource = when (type) {
+    FilterType.NowPlaying -> Res.string.now_playing
+    FilterType.TopRated -> Res.string.top_rated
+    FilterType.Popular -> Res.string.popular
+    FilterType.UpComing -> Res.string.upcoming
 }


### PR DESCRIPTION
# Pull Request Title
Refactor: Update FilterMenu to use items instead of count and index

## Description 📑
The FilterMenu composable was updated to utilize the `items` function instead of `count` and `index` for improved efficiency and readability and also added `toStringResource` function to get the string resource ID.

## Evidence

[refactor_menu_item_evidence.webm](https://github.com/user-attachments/assets/4d2c01e0-ef02-4b63-b1b1-d4379d5d19b7)
