### PR TITLE
Use `local.properties` instead of `gradle.properties` for API token 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If your bearer token is:
 Bearer cHuckNoRRisIsAWarRior
 ```
 
-Your `gradle.properties` file (_Global properties_) should looks like:
+Your `local.properties` file (_Global properties_) should have a line:
 
 ```
 MOVIE_DB_API_TOKEN=cHuckNoRRisIsAWarRior

--- a/src/composeApp/build.gradle.kts
+++ b/src/composeApp/build.gradle.kts
@@ -1,6 +1,7 @@
 @file:Suppress("UnstableApiUsage")
 
 import com.codingfeline.buildkonfig.compiler.FieldSpec
+import java.util.Properties
 
 plugins {
     id("kmp-app-plugin")
@@ -51,8 +52,15 @@ kotlin {
 buildkonfig {
     packageName = "com.gabrielbmoro.moviedb"
 
+    val properties = Properties()
+    val localPropertiesFile = rootProject.file("local.properties")
+    if (localPropertiesFile.exists()) {
+        properties.load(localPropertiesFile.inputStream())
+    }
+
     defaultConfigs {
-        val apiToken = findProperty("MOVIE_DB_API_TOKEN") as? String
+        val apiToken = properties.getProperty("MOVIE_DB_API_TOKEN")
+            ?: findProperty("MOVIE_DB_API_TOKEN") as? String
             ?: System.getenv("MOVIE_DB_API_TOKEN")
         buildConfigField(FieldSpec.Type.STRING, "API_TOKEN", apiToken)
     }

--- a/src/gradle.properties
+++ b/src/gradle.properties
@@ -18,4 +18,3 @@ org.gradle.jvmargs=-Xmx4608m
 
 # Disabled due to https://youtrack.jetbrains.com/issue/KT-65761
 kotlin.native.disableCompilerDaemon = true
-MOVIE_DB_API_TOKEN=eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJjYmIwMjk5Y2RiMzRhODE5YmM2ZmJiY2Q1M2JhMGVkNCIsIm5iZiI6MTYyNjU0NjI5Mi45MDIwMDAyLCJzdWIiOiI2MGYzMjA3NDdiN2I0ZDAwNzM1MDQ4Y2MiLCJzY29wZXMiOlsiYXBpX3JlYWQiXSwidmVyc2lvbiI6MX0._i3PNR1hZXO070WmNSCVyV_ZQyj09JE-KwZGCP9r4lM


### PR DESCRIPTION
## Description 📑

I accidentally pushed my API key on #297, because that: Use `local.properties` instead of `gradle.properties` for API token since `local.properties` is being ignored by `.gitignore`

- Updated the `README.md` to instruct users to put the API token in `local.properties` instead of `gradle.properties`.
- Modified the Gradle build script to read the API token from `local.properties` using `rootProject.file("local.properties")`.
- Removed the API Token from the `src/gradle.properties` file.

## Evidence:

https://github.com/user-attachments/assets/79c9f832-570f-44e9-900f-d55d06ae6c8e


