### PR TITLE
Remove detektcheck.sh script

### DIFF
--- a/scripts/detektcheck.sh
+++ b/scripts/detektcheck.sh
@@ -1,1 +1,0 @@
-detekt --input src -c src/config/detekt/detekt.yml -ex "**/build/**" -p ../lib/datekt-formatting-1.23.7.jar


### PR DESCRIPTION
# Remove detektcheck.sh script

## Description 📑

I updated my git pre-commit hook to be:

```shell
#!/bin/bash

cd src
./gradlew linter

if [ $? -ne 0 ]; then
    echo "Pre-commit hook failed due to script errors."
    exit 1
fi
echo "Pre-commit checks passed!"
```

It is working as expected, and using the incredible implementation that @PierreVieira made.

--

## Issues 🔖

- Closes https://github.com/gabrielbmoro/MovieDB-App/issues/310
