### PR TITLE
Ignore safe area container on iOS

### DIFF
--- a/src/iosApp/iosApp/ContentView.swift
+++ b/src/iosApp/iosApp/ContentView.swift
@@ -20,5 +20,6 @@ struct ContentView: View {
     var body: some View {
         ComposeView()
                 .ignoresSafeArea(.keyboard) // Compose has own keyboard handler
+                .ignoresSafeArea(.container)
     }
 }


### PR DESCRIPTION
## Description
Change made to have a more "beautiful" toolbar.

## Evidence

| Before | After |
| -- | -- |
| <img width="250" alt="ios_before" src="https://github.com/user-attachments/assets/e37abc36-cdfb-480f-b1a1-040ba08d4a7c" /> | <img width="250" alt="ios_after" src="https://github.com/user-attachments/assets/0741cef5-efa8-45bb-8947-84e15d5133b9" /> |


