### PR TITLE
Fix: Update README to use local.properties for the Bearer token.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ file using the Android Studio.
 1. Create an account [Movie DB API](https://www.themoviedb.org)
 (if you don't have it);
 2. Copy the value of your [Bearer token](https://developer.themoviedb.org/docs/authentication-application#bearer-token);
-3. Paste the value of your token your `gradle.properties` file (_Global properties_):
+3. Paste the value of your token your `local.properties` file (_Global properties_):
 
 If your bearer token is:
 


### PR DESCRIPTION
Simple `README.md` fix