### PR TITLE
Add network security configuration file for intercept android requests

### DIFF
--- a/src/composeApp/src/androidMain/AndroidManifest.xml
+++ b/src/composeApp/src/androidMain/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:name=".MovieDBApp"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"

--- a/src/composeApp/src/androidMain/res/xml/network_security_config.xml
+++ b/src/composeApp/src/androidMain/res/xml/network_security_config.xml
@@ -1,0 +1,14 @@
+<network-security-config>
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="user" />
+            <certificates src="system" />
+        </trust-anchors>
+    </debug-overrides>
+
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
# Pull Request Title

## Description 📑

Adds `network_security_config.xml` to allow debugging with user certificates and enforces HTTPS connections, and references the network security configuration in the `AndroidManifest.xml`.

## Evidence
Proxyman HTTP calls interception:

<img width="1150" alt="image" src="https://github.com/user-attachments/assets/61dc0a33-8dea-43e0-9ca4-f1cc7bb536dc" />

Even without Proxyman the connection still working normally:

| Android | iOS |
| -- | -- |
| <video width="280" src="https://github.com/user-attachments/assets/2f2a9f3f-590f-4e11-bf44-5042476419e1" /> | <video width="280" src="https://github.com/user-attachments/assets/10cedf00-6d95-48a3-8453-5da8277be69a" /> |

