### PR TITLE
Fix popcorn issues

### DIFF
--- a/.github/workflows/popcorn.yml
+++ b/.github/workflows/popcorn.yml
@@ -21,5 +21,9 @@ jobs:
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+
+      - name: Validate Gradle Wrapper
+        run: ./gradlew --version
+
       - name: Run popcorn
         run: ./gradlew popcorn


### PR DESCRIPTION
## Description 📑

This commit adds a step to the GitHub Actions workflow to validate the Gradle Wrapper version by running `./gradlew --version`.

