### PR TITLE
Avoid opencode reading local API key

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -4,6 +4,11 @@
   "skills": {
     "paths": ["ai/skills"]
   },
+  "permission": {
+    "read": { "**/local.properties": "deny" },
+    "grep": { "**/local.properties": "deny" },
+    "glob": { "**/local.properties": "deny" }
+  },
   "mcp": {
     "kotzilla": {
       "type": "remote",


### PR DESCRIPTION
## Description

Deny opencode access to `local.properties` to prevent it from reading the TMDB API token.

## Changes

- Added permission rules in `opencode.json` to block read, grep, and glob access to `**/local.properties` (+5 lines)

<img width="2431" height="1170" alt="image" src="https://github.com/user-attachments/assets/cce804c5-1a50-432e-b49d-fd9dec8ef7ac" />


## Commits

- `01f4481a` avoid opencode reads my local api tokens