### PR TITLE
Setup SDD — add README documentation for all modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,23 @@ src/
 └── build-logic/         # Convention plugins (kmp-library, koin-compiler, popcorngp)
 ```
 
+## Module READMEs
+
+Each Gradle module contains a `README.md` at its root (`src/<module>/README.md`). Before modifying or working within a module, read its README first to understand:
+
+- **Purpose** — why the module exists
+- **Primary Responsibility** — its single core job
+- **Existing Functionalities** — what it already does
+- **Entry Points** — key classes, signatures, and their roles
+- **Important Workflows** — step-by-step data/control flows
+- **Internal & External Dependencies** — what it depends on and what depends on it
+- **Related Modules** — modules it directly collaborates with
+- **Critical Files** — files that must not be broken
+- **Technical Notes** — architectural constraints, patterns, caveats
+- **Technical Debts** — known issues and future improvements needed
+
+Use `read_file` on the module's README.md as the first step when beginning work in any module.
+
 ## Navigation
 
 - **Type:** Jetpack Navigation Compose Multiplatform

--- a/opencode.json
+++ b/opencode.json
@@ -13,7 +13,7 @@
     "kotzilla": {
       "type": "remote",
       "url": "https://mcp.kotzilla.io/mcp",
-      "enabled": true
+      "enabled": false
     }
   }
 }

--- a/src/androidApp/README.md
+++ b/src/androidApp/README.md
@@ -1,0 +1,45 @@
+# androidApp
+
+## Purpose
+Android application shell module — the thin platform-specific entry point that hosts the shared `RootApp` composable inside a `ComponentActivity`, initializes Koin DI, and wires up Android-specific services (deep links, dynamic colors, Firebase, Kotzilla analytics).
+
+## Primary Responsibility
+- Provide the Android `Application` subclass (`MovieDBApp`) for Koin and service initialization
+- Host the shared Compose UI via `MainActivity` with `setContent { RootApp() }`
+- Define the `AndroidManifest.xml` with permissions, deep link intent filters, and launcher activity declaration
+- Apply Android-specific theming (Material You dynamic colors, edge-to-edge)
+
+## Existing Functionalities
+- **MovieDBApp** — `Application` subclass that calls `movieDbApplication { androidContext(this); analytics() }` to start Koin with the Android context and Kotzilla analytics
+- **MainActivity** — `ComponentActivity` with `launchMode="singleTask"`; `setContent` wraps `RootApp()` inside:
+  - `Rinku { }` — deep link handler composable
+  - `DynamicColorApp { }` — applies Material You dynamic colors (Android 12+ / API 31+) or falls back to the custom theme
+  - `enableEdgeToEdge()` — immersive edge-to-edge display
+- **AndroidManifest.xml** — declares `INTERNET` + `ACCESS_NETWORK_STATE` permissions; deep link intent filter for `http(s)://themoviedb.org` paths (`/movies`, `/movie/*`, `/favorite`, `/search`)
+- **network_security_config.xml** — blocks cleartext traffic in production; debug trusts user-installed certificates
+- **Resources** — launcher icons (5 densities), `colors.xml` (light + dark), `styles.xml` (AppCompat DayNight NoActionBar), `strings.xml`
+
+## Internal Dependencies
+
+| Dependency | Relationship |
+|---|---|
+| `:composeApp` | `implementation` (RootApp, DI aggregation, all feature screens) |
+
+### Key External Libraries
+- Jetpack Compose (activity-compose, Material3, Compose Multiplatform bundles), Koin (android + coroutines), Rinku (deep links), Kotzilla (analytics), Firebase Crashlytics, Google Services
+
+## External Dependencies (Consumers)
+- None — `androidApp` is a leaf module with no downstream consumers. It is the final deployable Android application artifact.
+
+## Technical Notes
+- `DynamicColorApp` is a private `@Composable` defined in `MainActivity.kt` — it checks `Build.VERSION.SDK_INT >= S` before attempting to generate dynamic color schemes.
+- `launchMode="singleTask"` ensures the activity is reused when deep links are opened, preventing duplicate instances.
+- Release signing is configured via Bitrise environment variables (`BITRISE_ANDROID_KEYSTORE_*`), not checked into the repository.
+- ProGuard is referenced in `build.gradle.kts` but `isMinifyEnabled = false` — minification is currently disabled for both debug and release builds.
+- Firebase Crashlytics and Kotzilla analytics are configured via `google-services.json` and `kotzilla.json` respectively.
+
+## Technical Debts
+- **Hardcoded TMDB API token**: `strings.xml` contains a hardcoded `token_value` (`755e0c67ac2fa886e775fb9057f0a32f`) — a v3 auth key exposed in source. This should be moved to `local.properties` / BuildKonfig or removed entirely (the app uses Bearer token auth via BuildKonfig).
+- **No tests**: this module has zero test files (no `src/test/` or `src/androidTest/`). While intentionally thin, instrumentation tests for deep link routing and activity launch should be considered.
+- **`isMinifyEnabled = false`** for release builds — no R8 obfuscation, shrinking, or optimization is applied to the final APK/AAB.
+- **`DynamicColorApp`** is a private composable in `MainActivity.kt` — could be extracted to a separate file or moved to `designsystem` for reuse across platforms.

--- a/src/androidApp/README.md
+++ b/src/androidApp/README.md
@@ -19,6 +19,51 @@ Android application shell module — the thin platform-specific entry point that
 - **network_security_config.xml** — blocks cleartext traffic in production; debug trusts user-installed certificates
 - **Resources** — launcher icons (5 densities), `colors.xml` (light + dark), `styles.xml` (AppCompat DayNight NoActionBar), `strings.xml`
 
+## Entry Points
+
+| Entry Point | File | Signature | Role |
+|---|---|---|---|
+| Application | `src/main/kotlin/.../MovieDBApp.kt` | `class MovieDBApp : Application()` | Koin initialization, analytics setup |
+| Activity | `src/main/kotlin/.../MainActivity.kt` | `class MainActivity : ComponentActivity()` | Hosts Compose UI with Rinku, dynamic colors, edge-to-edge |
+| Manifest | `src/main/AndroidManifest.xml` | — | Permissions, deep link intent filters, launcher declaration |
+| Theme wrapper | `src/main/kotlin/.../MainActivity.kt` | `@Composable private fun DynamicColorApp(...)` | Applies dynamic colors (API 31+) or custom theme fallback |
+
+## Important Workflows
+
+### App Launch on Android
+```
+Android system starts MainActivity (launchMode="singleTask")
+  → MovieDBApp.onCreate(): movieDbApplication { androidContext(this); analytics() }
+    → Koin started with Android context, dataModule, platformModule, DomainModule, lazy feature modules
+    → Kotzilla analytics SDK initialized
+  → MainActivity.setContent { Rinku { DynamicColorApp { enableEdgeToEdge(); RootApp() } } }
+    → Rinku wraps composable tree for deep link interception
+    → DynamicColorApp: checks Build.VERSION.SDK_INT >= 31
+      → API 31+: generates dynamicDarkColorScheme() or dynamicLightColorScheme()
+      → Below API 31: uses movieDBDarkColorScheme / movieDBLightColorScheme from :designsystem
+    → enableEdgeToEdge(): immersive display (status bar + nav bar transparent)
+    → RootApp() from :composeApp renders the full navigation graph
+```
+
+### Deep Link Handling (Android)
+```
+User taps https://themoviedb.org/movie/123
+  → AndroidManifest intent-filter matches the URI pattern
+  → MainActivity receives the intent (singleTask reuses existing instance)
+  → Rinku intercepts the deep link → forwards to DeeplinkEffect in :composeApp
+  → DeeplinkEffect maps path segments to navigation routes
+```
+
+## Critical Files
+
+| File | Role |
+|---|---|
+| `src/main/kotlin/.../MovieDBApp.kt` | Application subclass — Koin + analytics bootstrap |
+| `src/main/kotlin/.../MainActivity.kt` | ComponentActivity — Compose host, Rinku, dynamic colors, edge-to-edge |
+| `src/main/AndroidManifest.xml` | Permissions, deep link intent-filters, launchMode |
+| `src/main/res/values/strings.xml` | App name and (legacy) hardcoded TMDB token |
+| `src/main/res/xml/network_security_config.xml` | Cleartext blocking in release; user cert trust in debug |
+
 ## Internal Dependencies
 
 | Dependency | Relationship |

--- a/src/build-logic/README.md
+++ b/src/build-logic/README.md
@@ -1,0 +1,129 @@
+# build-logic
+
+## Purpose
+
+Convention plugins Gradle module (included build) that provides shared build configuration to all other project modules. Defines and enforces build standards through precompiled script plugins and a programmatic Gradle plugin.
+
+## Primary Responsibility
+
+Ensures consistent project configuration across all modules — KMP targets, Android SDK settings, Detekt static analysis, Koin compiler setup, and Popcorn Guineapig architecture dependency rule enforcement.
+
+## Existing Functionalities
+
+- **`kmp-library-plugin`** — Applies KMP + Android Library configuration to any module that uses it. Sets Android `minSdk` (28), `compileSdk` (36), namespace generation (`com.gabrielbmoro.moviedb.<module-name>`), and iOS target registration (gated by `kmp.enableIos` property). Also applies `detekt-setup-plugin` automatically.
+- **`detekt-setup-plugin`** — Applies Detekt with a base configuration overridden by custom rules at `$rootDir/config/detekt/detekt.yml`. Includes the `detekt-formatting` plugin. Sources scoped to `commonMain`, `androidMain`, `iosMain`.
+- **`koin-compiler-setup`** — Programmatic plugin that applies the Koin Compiler Plugin (`io.insert-koin.compiler.plugin`) with `userLogs = true` and `compileSafety = true`. Adds `koin.core` and `koin.annotations` to `commonMain`. Replaces the older KSP-based Koin approach.
+- **`popcorngp-setup-plugin`** — Applies Popcorn Guineapig with `KMP` project type. Enforces Clean Architecture dependency rules:
+  - `:domain`, `:platform`, `:designsystem` — NoDependencyRule (zero project dependencies)
+  - `:data` — JustWithRule (can only depend on `:domain`)
+  - `:feature-*` — DoNotWithRule (must not depend on `:data`)
+- **Configuration models** — Centralized constants: `APPLICATION_ID`, `APP_NAME`, `JavaConfiguration` (JVM 21), `SdkConfiguration` (minSdk=28, targetSdk=36, compileSdk=36)
+- **Auto-versioning** — Reads `BITRISE_BUILD_NUMBER` from CI environment for version code/name; falls back to `10` / `"1.0.0"` locally, major version `"1.8"`
+- **iOS target gating** — iOS targets (`iosX64`, `iosArm64`, `iosSimulatorArm64`) are only configured when Gradle property `kmp.enableIos` is set, enabling CI iOS builds without requiring macOS for every developer
+- **Framework configuration** — iOS framework produced as a static framework named `ComposeApp`
+
+## Entry Points
+
+| Plugin | Plugin ID | File | Type |
+|---|---|---|---|
+| KMP Library | `kmp-library-plugin` | `plugins/kmp-library-plugin.gradle.kts` | Precompiled script |
+| Detekt | `detekt-setup-plugin` | `plugins/detekt-setup-plugin.gradle.kts` | Precompiled script |
+| Koin Compiler | `koin-compiler-setup` | `plugins/KoinCompilerSetupPlugin.kt` | Programmatic (`class`) |
+| Popcorn Guineapig | `popcorngp-setup-plugin` | `plugins/popcorngp-setup-plugin.gradle.kts` | Precompiled script |
+
+These plugins are applied by module `build.gradle.kts` files via the Gradle `plugins {}` DSL using the plugin IDs listed above.
+
+## Important Workflows
+
+### Module Build Configuration Flow
+```
+Module build.gradle.kts applies kmp-library-plugin
+  → kmp-library-plugin applies:
+      kotlin.multiplatform
+      com.android.kotlin.multiplatform.library
+      detekt-setup-plugin
+  → kmp-library-plugin configures:
+      Android SDK (minSdk=28, compileSdk=36)
+      Namespace = com.gabrielbmoro.moviedb.<module>
+      iOS targets (if kmp.enableIos=true)
+      Static framework named "ComposeApp"
+```
+
+### Architecture Rule Enforcement (Popcorn Guineapig)
+```
+./gradlew :build-logic:checkPopcornGuineapig
+  → Popcorn Guineapig scans all project modules
+  → For each module matching a pattern, applies the associated rule
+  → Failures are reported as build errors with the violating dependency
+```
+
+Rules applied by pattern:
+- `:platform`, `:domain`, `:designsystem` → NoDependencyRule (must be leaf modules)
+- `:data` → JustWithRule(justWith=["domain"])
+- `:feature-[a-z]+` → DoNotWithRule(notWith=["data"])
+
+### Koin Compiler Plugin Flow
+```
+Module applies koin-compiler-setup plugin
+  → KoinCompilerSetupPlugin applies io.insert-koin.compiler.plugin
+  → Configures KoinGradleExtension: userLogs=true, compileSafety=true
+  → Adds koin.core + koin.annotations to commonMainImplementation
+  → Koin compiler processes @Module, @Factory, @Single annotations at compile time
+  → Generates module bindings without KSP
+```
+
+## Critical Files
+
+| File | Role |
+|---|---|
+| `plugins/kmp-library-plugin.gradle.kts` | Base KMP + Android Library configuration applied by all modules |
+| `plugins/detekt-setup-plugin.gradle.kts` | Detekt static analysis with custom rules |
+| `plugins/KoinCompilerSetupPlugin.kt` | Programmatic plugin for Koin compiler (replaces KSP) |
+| `plugins/popcorngp-setup-plugin.gradle.kts` | Architecture dependency rule enforcement |
+| `config/ConfigurationKeys.kt` | Centralized constants (application ID, app name, SDK, Java versions) |
+| `config/Versioning.kt` | CI-driven version code/name with local fallbacks |
+| `ext/KotlinMultiPlatformExt.kt` | iOS target registration and framework configuration |
+| `ext/ProjectExt.kt` | Version catalog accessor extension |
+| `model/JavaConfiguration.kt` | JVM target data class (version, target string, JvmTarget) |
+| `model/SdkConfiguration.kt` | Android SDK data class (min, target, compile) |
+
+## Internal Dependencies
+
+The `build-logic` included build has no dependencies on other project modules. It is a completely separate Gradle build that is included via `includeBuild("build-logic")` in `settings.gradle.kts`.
+
+## External Dependencies
+
+All declared in `build-logic/build.gradle.kts`:
+
+| Dependency | Purpose |
+|---|---|
+| `kotlin-gradle-plugin` | Kotlin compiler for KMP |
+| Android Gradle Plugin (`gradle`) | Android target configuration |
+| KSP Gradle Plugin | Required by the classpath; Koin compiler replaces KSP, but the plugin is available |
+| `popcorn-guineapig` | Architecture dependency rule enforcement |
+| `koin-compiler-plugin` | Koin annotation processing at compile time |
+| `detekt-gradle-plugin` | Static analysis |
+
+## Related Modules
+
+- **All project modules** depend on `build-logic` plugins — every `build.gradle.kts` applies at least `kmp-library-plugin` to inherit the base KMP + Android configuration
+- **`:composeApp`** additionally applies `koin-compiler-setup` (for Koin annotation processing)
+- **Root `build.gradle.kts`** applies `popcorngp-setup-plugin` at the project level to enforce architecture rules globally
+
+## Technical Notes
+
+- **Included build** — `build-logic` is an included build (`includeBuild("build-logic")` in settings), meaning its plugins are resolved before any project module builds
+- **Precompiled script plugins** — `.gradle.kts` files in `src/main/kotlin/plugins/` are auto-discovered by the `kotlin-dsl-precompiled-script-plugins` plugin and become usable as plugin IDs
+- **Programmatic plugin registration** — `KoinCompilerSetupPlugin` is registered in `build-logic/build.gradle.kts` via `gradlePlugin.plugins.create("koin-compiler-setup")`, mapping the plugin ID to the implementation class
+- **Included build access** — modules access the `libs` version catalog from `build-logic` via the `val Project.libs` extension property
+- **iOS conditional compilation** — iOS targets are gated by the Gradle property `kmp.enableIos`. When unset, iOS source sets are not compiled, allowing developers on non-macOS machines to build without errors. CI environments set this property.
+- **Popcorn Guineapig task** — `checkPopcornGuineapig` runs as `./gradlew :build-logic:checkPopcornGuineapig` and reports violations as build failures
+
+## Technical Debts
+
+1. **No README existed for this module** — documentation gap filled as of this writing
+2. **KSP plugin on classpath but unused** — Koin compiler replaced KSP for annotations, but the KSP Gradle plugin remains as a build-logic dependency; some modules still apply KSP directly for Room's KSP annotation processor (Room has no compiler plugin equivalent yet)
+3. **Hardcoded major version** (`"1.8"`) in `Versioning.kt` — should be derived from a tag or a TOML property to avoid manual bumps
+4. **`APP_NAME` constant used for both Android namespace and iOS framework name** — coupling that could break if one platform needs a different name
+5. **No tests for convention plugins** — Gradle plugin behavior is verified only through full project builds (`./gradlew build`), not via unit tests for the plugins themselves
+6. **iOS target configuration in `KotlinMultiPlatformExt.kt` assumes three specific iOS targets** — if KMP adds new iOS targets in future Kotlin versions, this file will need manual updates

--- a/src/build-logic/README.md
+++ b/src/build-logic/README.md
@@ -51,7 +51,7 @@ Module build.gradle.kts applies kmp-library-plugin
 
 ### Architecture Rule Enforcement (Popcorn Guineapig)
 ```
-./gradlew :build-logic:checkPopcornGuineapig
+./gradlew popcornParent
   → Popcorn Guineapig scans all project modules
   → For each module matching a pattern, applies the associated rule
   → Failures are reported as build errors with the violating dependency
@@ -117,7 +117,7 @@ All declared in `build-logic/build.gradle.kts`:
 - **Programmatic plugin registration** — `KoinCompilerSetupPlugin` is registered in `build-logic/build.gradle.kts` via `gradlePlugin.plugins.create("koin-compiler-setup")`, mapping the plugin ID to the implementation class
 - **Included build access** — modules access the `libs` version catalog from `build-logic` via the `val Project.libs` extension property
 - **iOS conditional compilation** — iOS targets are gated by the Gradle property `kmp.enableIos`. When unset, iOS source sets are not compiled, allowing developers on non-macOS machines to build without errors. CI environments set this property.
-- **Popcorn Guineapig task** — `checkPopcornGuineapig` runs as `./gradlew :build-logic:checkPopcornGuineapig` and reports violations as build failures
+- **Popcorn Guineapig task** — `popcornParent` runs as `./gradlew popcornParent` and reports violations as build failures
 
 ## Technical Debts
 

--- a/src/composeApp/README.md
+++ b/src/composeApp/README.md
@@ -1,0 +1,47 @@
+# composeApp
+
+## Purpose
+UI orchestrator module — the central hub that assembles the navigation graph, aggregates all Koin DI modules, and hosts the shared `RootApp` composable consumed by both Android and iOS entry points.
+
+## Primary Responsibility
+- Owns the `NavHost` with all four screen routes: `Movies`, `Details/{movieId}`, `Search`, `Wishlist`
+- Aggregates all Koin modules via `AppModules.kt` (`movieDbApplication` function)
+- Handles deep link routing across platforms (`DeeplinkEffect.kt`)
+- Serves as the single runtime dependency hub — depends on every other module so that downstream consumers (androidApp, iosApp) only need to depend on `composeApp`
+
+## Existing Functionalities
+- **Navigation graph** — Jetpack Navigation Compose `NavHost` in `RootApp.kt` wiring each route to its feature screen
+- **DI aggregation** — starts Koin with data, platform, domain, and all feature modules via `lazyModules`
+- **Deep link handling** — `DeeplinkEffect.kt` listens for Rinku `DeepLinkListener` events and emits routes for `movie/{id}`, `favorite`, `search?query=`
+- **iOS Koin init** — `KoinHelper.kt` provides `initKoin()` called from Swift
+- **iOS Compose bridge** — `MainViewController.kt` creates `ComposeUIViewController` wrapping `RootApp()` inside `MovieDBAppTheme`
+
+## Internal Dependencies
+
+| Dependency | Relationship |
+|---|---|
+| `:designsystem` | `api` (theme, shared UI components propagated) |
+| `:platform` | `implementation` (navigation, ViewModel base, logging) |
+| `:domain` | `implementation` (repository interfaces, use cases) |
+| `:data` | `implementation` (DI module, repository impl) |
+| `:feature-movies` | `implementation` (MoviesScreen) |
+| `:feature-details` | `implementation` (DetailsScreen) |
+| `:feature-search` | `implementation` (SearchScreen) |
+| `:feature-wishlist` | `implementation` (WishlistScreen) |
+
+### Key External Libraries
+- Jetpack Navigation Compose, Rinku (deep links), Koin (core + coroutines)
+
+## External Dependencies (Consumers)
+- `androidApp` — depends on `composeApp` for the shared `RootApp()` composable
+- `iosApp` — imports the `ComposeApp` framework (built from this module)
+
+## Technical Notes
+- `designsystem` is declared as `api` so all consumers transitively get the theme and shared UI components
+- `LocalNavController` composition local is provided at this level via `CompositionLocalProvider`
+- Koin uses `lazyModules()` for feature modules (lazy-loading) and eager modules for `data` and `platform`
+- Deep links are Android-only (Rinku); iOS uses standard Compose navigation
+
+## Technical Debts
+- The `DeeplinkEffect` routes are duplicated across `DeeplinkEffect.kt` and `androidApp` manifest. Consider centralizing route definitions.
+- `RootApp.kt` directly instantiates screens; consider a navigation-level use case or coordinator.

--- a/src/composeApp/README.md
+++ b/src/composeApp/README.md
@@ -16,6 +16,62 @@ UI orchestrator module — the central hub that assembles the navigation graph, 
 - **iOS Koin init** — `KoinHelper.kt` provides `initKoin()` called from Swift
 - **iOS Compose bridge** — `MainViewController.kt` creates `ComposeUIViewController` wrapping `RootApp()` inside `MovieDBAppTheme`
 
+## Entry Points
+
+| Entry Point | File | Signature | Role |
+|---|---|---|---|
+| Root composable | `src/commonMain/kotlin/RootApp.kt` | `@Composable fun RootApp()` | Builds `NavHost` with all 4 screen routes, provides `LocalNavController` |
+| DI aggregator | `src/commonMain/kotlin/di/AppModules.kt` | `fun movieDbApplication(platformBlock: KoinApplication.() -> Unit): KoinApplication` | Starts Koin with all modules (data, platform, domain eagerly; features lazily) |
+| Deep link effect | `src/commonMain/kotlin/DeeplinkEffect.kt` | `@Composable fun DeeplinkEffect()` | Listens for Rinku deep links, maps URI paths to navigation routes |
+| iOS Koin init | `src/iosMain/kotlin/.../KoinHelper.kt` | `fun initKoin()` | iOS-side Koin initialization, called from Swift |
+| iOS UI bridge | `src/iosMain/kotlin/.../MainViewController.kt` | `fun MainViewController(): UIViewController` | Creates `ComposeUIViewController` hosting the shared UI tree |
+
+## Important Workflows
+
+### DI Initialization Flow
+```
+App launch (Android: MovieDBApp.onCreate / iOS: iosAppApp.init)
+  → movieDbApplication { }
+    → Eager registration: dataModule, platformModule, DomainModule
+    → Lazy registration: featureMoviesModule, featureDetailsModule,
+      featureSearchMovieModule, featureWishlistModule
+  → Koin container ready before any composable runs
+```
+
+### Navigation Wiring Flow
+```
+RootApp()
+  → rememberNavController()
+  → CompositionLocalProvider(LocalNavController provides navController)
+    → DeeplinkEffect() starts listening for Rinku deep link events
+    → NavHost(startDestination = Screen.Movies.route)
+      → addMoviesScreen { MoviesScreen() }
+      → addMovieDetailsScreen { movieId -> DetailsScreen(movieId) }
+      → addSearchScreen { query -> SearchScreen(query) }
+      → addWishlistScreen { WishlistScreen() }
+```
+
+### Deep Link Routing Flow
+```
+Rinku receives URI (e.g., movie://movie/123?query=batman)
+  → DeepLinkListener callback with path segments
+  → DeeplinkEffect matches firstSegment against Screen enum:
+    - "movie" → extracts movieId from second segment → navigates to Details
+    - "favorite" → navigates to Wishlist
+    - "search" → extracts query parameter → navigates to Search
+  → Unknown segments: logged via println (not LoggerHelper)
+```
+
+## Critical Files
+
+| File | Role |
+|---|---|
+| `src/commonMain/kotlin/RootApp.kt` | Navigation graph assembly; provides `LocalNavController` |
+| `src/commonMain/kotlin/di/AppModules.kt` | Koin DI bootstrap — the single aggregation point for all modules |
+| `src/commonMain/kotlin/DeeplinkEffect.kt` | Rinku deep link → navigation route bridge |
+| `src/iosMain/kotlin/.../KoinHelper.kt` | iOS Koin initialization entry point |
+| `src/iosMain/kotlin/.../MainViewController.kt` | iOS ComposeUIViewController factory |
+
 ## Internal Dependencies
 
 | Dependency | Relationship |
@@ -45,3 +101,5 @@ UI orchestrator module — the central hub that assembles the navigation graph, 
 ## Technical Debts
 - The `DeeplinkEffect` routes are duplicated across `DeeplinkEffect.kt` and `androidApp` manifest. Consider centralizing route definitions.
 - `RootApp.kt` directly instantiates screens; consider a navigation-level use case or coordinator.
+- **Inconsistent package declarations**: `RootApp.kt` and `DeeplinkEffect.kt` have no package declaration; `AppModules.kt` uses `package di`; `MainViewController.kt` has no package. The project convention is `com.gabrielbmoro.moviedb.*`.
+- **Raw `println` for logging**: `DeeplinkEffect.kt` line 59 uses `println("Not mapped")` instead of the project's standard `LoggerHelper` (Kermit) from `:platform`.

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -1,0 +1,52 @@
+# data
+
+## Purpose
+Data layer module — implements repository interfaces defined in `domain`, providing the concrete wiring to TMDB's REST API (via Ktor) and local persistence (via Room). This is the only module that depends on `:domain` and hosts all data-source concerns.
+
+## Primary Responsibility
+- Implement `MoviesRepository` interface from `domain`
+- Own all DTOs, API response models, Room entities/DAOs, and mapper functions
+- Provide platform-specific HTTP clients and database instances via `expect`/`actual`
+
+## Existing Functionalities
+- **API client** (`ApiService.kt`) — Ktor-based HTTP client for TMDB endpoints:
+  - `GET /movie/{category}?page={n}` — movie listings
+  - `GET /movie/{id}` — movie details
+  - `GET /movie/{id}/videos` — video streams
+  - `GET /search/movie?query={q}` — search
+- **Local database** — Room with `FavoriteMovieDTO` entity and `FavoriteMoviesDAO` (CRUD + favorite toggling)
+- **Repository implementation** (`MoviesDataRepository.kt`) — delegates to `ApiService` and `FavoriteMoviesDAO`, mapping between DTOs and domain models
+- **Mappers** — `ResponseMappers.kt` (API responses → domain), `DataTransferObjMappers.kt` (domain ↔ Room DTOs)
+- **BuildKonfig** — reads `MOVIE_DB_API_TOKEN` from `local.properties` / environment, generates `BuildKonfig.API_TOKEN`
+- **Platform providers** — `expect`/`actual` for `httpClientEngine()` (OkHttp on Android, Darwin on iOS) and `databaseInstance()` (Room with platform-specific setup)
+
+## Internal Dependencies
+
+| Dependency | Relationship |
+|---|---|
+| `:domain` | `implementation` (repository interfaces, domain models) |
+
+### Key External Libraries
+- Ktor (client-core, content-negotiation, kotlinx-json, auth, logging)
+- Room (runtime, compiler via KSP)
+- SQLite (bundled driver for iOS)
+- BuildKonfig (compile-time config generation)
+- Koin (core, annotations — DI module)
+
+## External Dependencies (Consumers)
+- `:composeApp` — aggregates `dataModule` eagerly via Koin
+- No feature module depends on `:data` directly (enforced by Popcorn Guineapig)
+
+## Technical Notes
+- **Popcorn Guineapig rule**: `JustWithRule(justWith=["domain"])` — this module can ONLY depend on `:domain`
+- `BuildKonfig` is configured in this module's `build.gradle.kts`, so the API token is only accessible to `:data`
+- Room KSP is applied per-platform: `kspAndroid`, `kspIosSimulatorArm64`, `kspIosX64`, `kspIosArm64`
+- Room schema directory is configured at `$projectDir/schemas` for migration exports
+- `MoviesDataRepository` receives `ApiService` and `FavoriteMoviesDAO` via Koin constructor injection
+- Image URLs are constructed in mappers using `https://image.tmdb.org/t/p/w300` (thumbnails) and `w780` (large)
+
+## Technical Debts
+- Room database version is hardcoded in `DatabaseProvider.kt`; consider version catalog entry
+- No repository-level caching strategy — every call hits the network or database directly
+- Mapper tests exist but repository implementation tests are missing
+- `FavoriteMovieDTO` stores redundant fields (`backdropImageUrl`, `releaseDate`, `language`, `popularity`) that mirror the API response instead of normalizing to domain-only needs

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -20,6 +20,79 @@ Data layer module — implements repository interfaces defined in `domain`, prov
 - **BuildKonfig** — reads `MOVIE_DB_API_TOKEN` from `local.properties` / environment, generates `BuildKonfig.API_TOKEN`
 - **Platform providers** — `expect`/`actual` for `httpClientEngine()` (OkHttp on Android, Darwin on iOS) and `databaseInstance()` (Room with platform-specific setup)
 
+## Entry Points
+
+| Entry Point | File | Signature | Role |
+|---|---|---|---|
+| DI module | `src/commonMain/kotlin/.../data/di/DataModule.kt` | `val dataModule = module { }` | Koin module providing `MoviesRepository`, `HttpClient`, `ApiService`, DAO |
+| API service | `src/commonMain/kotlin/.../datasources/ktor/ApiService.kt` | `class ApiService(baseUrl, httpClient)` | Ktor HTTP client for TMDB API endpoints |
+| Repository impl | `src/commonMain/kotlin/.../repository/MoviesDataRepository.kt` | `internal class MoviesDataRepository(...) : MoviesRepository` | Implements domain repository interface, delegates to API + DAO |
+| DB provider | `src/commonMain/kotlin/.../providers/DatabaseProvider.kt` | `expect fun databaseInstance(): AppDatabase` | Platform-specific Room database instantiation |
+| HTTP engine | `src/commonMain/kotlin/.../providers/HttpClientEngineProvider.kt` | `expect fun httpClientEngine(): HttpClientEngine` | Platform-specific HTTP engine (OkHttp/Darwin) |
+
+## Important Workflows
+
+### Data Fetch Flow (API → Domain Model)
+```
+Feature ViewModel calls MoviesRepository.getMoviesFromFilter(filter, page)
+  → MoviesDataRepository (internal class in :data)
+    → ApiService.getMovies(category, pageNumber)
+      → httpClient.get("$baseUrl/movie/$category?page=$pageNumber")
+        → Ktor: Bearer auth header, JSON content negotiation
+        → Response → check isSuccess()
+          → Success: deserialize to PageResponse, extract .results
+          → Failure: throw HttpException(statusCode, statusDescription, url, method)
+    → ResponseMappers: MovieResponse.toMovie() extension
+      → Constructs IMAGE_BASE_URL/w300 for poster, IMAGE_BASE_URL/w780 for backdrop
+      → Maps fields: id, title, overview, vote_average, release_date, etc.
+    → Returns List<Movie> to feature module
+```
+
+### Local Persistence Flow (Favorites)
+```
+Feature ViewModel calls MoviesRepository.favorite(movie)
+  → MoviesDataRepository
+    → DataTransferObjMappers: Movie.toFavoriteMovieDTO()
+      → Maps Movie.id → FavoriteMovieDTO.movieId (Room auto-generates its own id)
+    → FavoriteMoviesDAO.saveFavorite(favoriteMovieDTO)
+      → INSERT with OnConflictStrategy.REPLACE
+
+Feature ViewModel calls MoviesRepository.getFavoriteMovies()
+  → MoviesDataRepository
+    → FavoriteMoviesDAO.allFavoriteMovies() → List<FavoriteMovieDTO>
+    → DataTransferObjMappers: FavoriteMovieDTO.toMovie()
+      → Maps FavoriteMovieDTO.movieId → Movie.id
+      → Sets isFavorite = true (hardcoded — DTO existence = favorited)
+```
+
+### Platform Resolution (expect/actual)
+```
+DataModule requests databaseInstance() at DI time
+  → Common: expect fun databaseInstance(): AppDatabase
+  → Android actual: Room.databaseBuilder(context, AppDatabase::class.java, dbFileName).build()
+  → iOS actual: Room.databaseBuilder with BundledSQLiteDriver, NSFileManager documents dir
+
+DataModule requests httpClientEngine() for Ktor client
+  → Common: expect fun httpClientEngine(): HttpClientEngine
+  → Android actual: OkHttpEngine(OkHttpConfig())
+  → iOS actual: Darwin.create()
+```
+
+## Critical Files
+
+| File | Role |
+|---|---|
+| `.../di/DataModule.kt` | Koin DI wiring — binds `MoviesRepository`, `HttpClient`, `ApiService`, DAO |
+| `.../datasources/ktor/ApiService.kt` | Ktor HTTP client with all 4 TMDB endpoint methods |
+| `.../repository/MoviesDataRepository.kt` | Repository implementation (internal class) — orchestrates API + Room |
+| `.../datasources/ktor/responses/*.kt` (6 files) | `@Serializable` DTOs matching TMDB JSON schema |
+| `.../datasources/database/room/FavoriteMoviesDAO.kt` | Room DAO — CRUD operations on favorite_movies table |
+| `.../datasources/database/room/dto/FavoriteMovieDTO.kt` | Room `@Entity` — persisted favorite movie record |
+| `.../mappers/ResponseMappers.kt` | API JSON responses → domain models (Movie, MovieDetail, VideoStream) |
+| `.../mappers/DataTransferObjMappers.kt` | Domain models ↔ Room DTOs (for favorites) |
+| `.../providers/DatabaseProvider.kt` | `expect fun databaseInstance()` — platform Room init |
+| `.../providers/HttpClientEngineProvider.kt` | `expect fun httpClientEngine()` — platform HTTP engine |
+
 ## Internal Dependencies
 
 | Dependency | Relationship |
@@ -50,3 +123,6 @@ Data layer module — implements repository interfaces defined in `domain`, prov
 - No repository-level caching strategy — every call hits the network or database directly
 - Mapper tests exist but repository implementation tests are missing
 - `FavoriteMovieDTO` stores redundant fields (`backdropImageUrl`, `releaseDate`, `language`, `popularity`) that mirror the API response instead of normalizing to domain-only needs
+- **`MoviesDataRepository` has no tests** — only the mapper extension functions (`MappersExtTest`) have test coverage. No integration or unit tests verify repository behavior against fake API/DAO.
+- **`FavoriteMovieDTO` dual-ID design**: Room auto-generates `id: Int?` while TMDB's ID is stored as `movieId: Long`. This subtle distinction is easy to misuse in mappers.
+- **API token scope**: `BuildKonfig.API_TOKEN` is available only within `:data` via `BuildKonfig` generated class, but the token string originates from `local.properties` — an external configuration dependency with no fallback validation.

--- a/src/designsystem/README.md
+++ b/src/designsystem/README.md
@@ -1,0 +1,46 @@
+# designsystem
+
+## Purpose
+Shared UI module — provides the design tokens (colors, typography), reusable composable components, and the Material 3 theme wrapper consumed by all feature modules. A LEAF module with no project dependencies.
+
+## Primary Responsibility
+- Define the `MovieDBAppTheme` composable (dark/light color schemes, Material 3 integration)
+- Provide reusable UI composables: cards, toolbars, image loaders, error screens, loaders, icons, buttons
+- Host compose resources (strings, drawables) shared across feature modules
+
+## Existing Functionalities
+- **Theme** — `Color.kt` (amber/gold primary color schemes: `movieDBDarkColorScheme`, `movieDBLightColorScheme`), `Theme.kt` (`MovieDBAppTheme` composable with optional dynamic color support)
+- **Cards** — `MovieCard` (poster + info, optional delete button), `MovieCardInformation` (title, star rating, description)
+- **Toolbars** — `AppToolbarTitle` (standard top bar), `CustomAppToolbar` (slot-based top bar), `AnimatedAppToolbar` (visibility animation wrapper), `NavigationBottomBar` (Movies | Favorite tabs)
+- **Images** — `AsyncImage` (Coil 3 wrapper with progress/error states), `MovieImage` (image or placeholder), `EmptyState` (sad emoji + text), `FiveStars` (0-5 star rating display from vote average)
+- **Error** — `ErrorInfo` (enum: `SOMETHING_WRONG_HAPPENED`, `NETWORK_ERROR`, `PLEASE_TRY_AGAIN`), `ErrorScreen` (composable with retry action)
+- **Loaders** — `BubbleLoader` (animated three-bubble canvas loader)
+- **Icons** — `BackNavigationIcon`, `SearchNavigationIcon` (Material icon buttons)
+- **Buttons** — `DeleteButton` (trash icon button)
+- **Resources** — strings.xml (localized labels), drawable XML icons (star variants, movie media player, navigation, sad emoji)
+
+## Internal Dependencies
+- **None** — LEAF module, no project module dependencies (enforced by Popcorn Guineapig `NoDependencyRule`)
+
+### Key External Libraries
+- Compose Multiplatform (ui, foundation, material3, runtime, animation, ui-util, material-icons-extended)
+- Coil 3 (compose + ktor3 network fetcher)
+
+## External Dependencies (Consumers)
+- `:composeApp` — declared as `api` dependency, so all consumers transitively inherit theme/components
+- `:feature-movies`, `:feature-details`, `:feature-search`, `:feature-wishlist` — use cards, toolbars, images, loaders, error components
+
+## Technical Notes
+- **Popcorn Guineapig rule**: `NoDependencyRule` — must have NO project module dependencies
+- `AsyncImage` uses Coil 3 with `KtorNetworkFetcherFactory` for consistent networking across platforms
+- `FiveStars` maps TMDB's 0-10 vote average to 0-5 stars with half-star support
+- Material 3 `ColorScheme` definitions include all 30+ color tokens for complete theme support
+- `NavigationBottomBar` is a two-tab bar (Movies index 0, Wishlist index 1) — not a general-purpose navigation component
+- String resources are localized via `composeResources/values/strings.xml`
+
+## Technical Debts
+- **Typo in package path**: `com/gabrielbmoro/moviedb/desingsystem/` — missing `i` in "designsystem" (`deSignsystem` should be `deSignSystem`). The package name matches the directory, so changing either requires updating all imports across the app.
+- `FiveStars` uses hardcoded star icon resources — doesn't support custom icon sets
+- `BubbleLoader` uses raw `Canvas` drawing instead of Material 3 `CircularProgressIndicator`
+- `NavigationBottomBar` is fixed to two tabs — not extensible without code changes
+- No unit tests exist for any composable (no Compose UI testing setup)

--- a/src/designsystem/README.md
+++ b/src/designsystem/README.md
@@ -19,6 +19,74 @@ Shared UI module — provides the design tokens (colors, typography), reusable c
 - **Buttons** — `DeleteButton` (trash icon button)
 - **Resources** — strings.xml (localized labels), drawable XML icons (star variants, movie media player, navigation, sad emoji)
 
+## Entry Points
+
+| Entry Point | File | Signature | Role |
+|---|---|---|---|
+| Theme wrapper | `src/commonMain/kotlin/.../theme/Theme.kt` | `@Composable fun MovieDBAppTheme(dynamicColorScheme: ColorScheme?, content: @Composable () -> Unit)` | Material 3 theme with optional dynamic color injection |
+| Color schemes | `src/commonMain/kotlin/.../theme/Color.kt` | `val movieDBDarkColorScheme: ColorScheme`, `val movieDBLightColorScheme: ColorScheme` | Amber/gold custom color schemes (30+ tokens) |
+| Movie card | `src/commonMain/kotlin/.../cards/MovieCard.kt` | `@Composable fun MovieCard(imageUrl, title, description, votes, onClick, enableDelete, onDeleteClick)` | Primary movie card used across all feature screens |
+| Image loader | `src/commonMain/kotlin/.../images/MovieImage.kt` | `@Composable fun MovieImage(imageUrl, contentDescription, contentScale)` | Public image composable — delegates to internal `AsyncImage` with placeholder fallback |
+| Five stars | `src/commonMain/kotlin/.../images/FiveStars.kt` | `@Composable fun FiveStars(votes: Float)` | TMDB 0-10 vote → 5-star display with half-star support |
+| Error screen | `src/commonMain/kotlin/.../error/ErrorScreen.kt` | `@Composable fun ErrorScreen(errorInfo: ErrorInfo, onRetry: (() -> Unit)?)` | Full-screen error with optional retry button |
+| Toolbars | `src/commonMain/kotlin/.../toolbars/*.kt` (4 files) | `AppToolbarTitle`, `CustomAppToolbar`, `AnimatedAppToolbar`, `NavigationBottomBar` | Standard top bars and 2-tab bottom navigation |
+| Internal image | `src/commonMain/kotlin/.../images/AsyncImage.kt` | `internal fun AsyncImage(...)` | Coil 3 wrapper with loading/error states (not exported) |
+
+## Important Workflows
+
+### Theme Resolution Flow
+```
+MovieDBAppTheme(dynamicColorScheme = platformProvidedScheme)
+  → If dynamicColorScheme != null: MaterialTheme(colorScheme = dynamicColorScheme)
+    → Android: MainActivity.DynamicColorApp generates dynamicDarkColorScheme/LightColorScheme (API 31+)
+    → iOS: always null → uses fallback
+  → If dynamicColorScheme == null: MaterialTheme(colorScheme = if (isSystemInDarkTheme()) movieDBDarkColorScheme else movieDBLightColorScheme)
+  → No custom Typography or Shapes — uses Material3 defaults
+```
+
+### Image Loading Flow
+```
+MovieImage(imageUrl = "https://image.tmdb.org/t/p/w300/abc.jpg")
+  → If imageUrl == null: show ic_movie_media_player placeholder
+  → If imageUrl != null: delegate to internal AsyncImage
+    → AsyncImage builds Coil ImageRequest with KtorNetworkFetcherFactory
+    → SubcomposeAsyncImage renders:
+      - Loading state: CircularProgressIndicator (52dp max)
+      - Success state: loaded image with contentScale
+      - Error state: custom onFailure composable (passed from MovieImage)
+```
+
+### Movie Card Composition Flow
+```
+MovieCard(imageUrl, title, description, votes, onClick, enableDelete, onDeleteClick)
+  → Card (rounded 12dp corners, elevation)
+    → MovieImage (200dp height, FillWidth scale) — poster or placeholder
+    → MovieCardInformation (title bold, FiveStars, description italic)
+    → If enableDelete: DeleteButton overlay (48dp, positioned with BoxScope.align)
+```
+
+## Critical Files
+
+| File | Role |
+|---|---|
+| `.../theme/Color.kt` | 30+ color constants + `movieDBDarkColorScheme` / `movieDBLightColorScheme` |
+| `.../theme/Theme.kt` | `MovieDBAppTheme` — Material 3 wrapper with dynamic color support |
+| `.../cards/MovieCard.kt` | Primary card — image + info + optional delete button |
+| `.../images/AsyncImage.kt` | Internal Coil 3 wrapper — loading/error/empty states (not exported) |
+| `.../images/MovieImage.kt` | Public image — null-safe with ic_movie_media_player placeholder |
+| `.../images/FiveStars.kt` | 0-10 vote average → 5 star icons (star, half-star, border) |
+| `.../error/ErrorScreen.kt` | Error state composable — icon + message + optional retry button |
+| `.../error/ErrorInfo.kt` | Error discriminator enum: SOMETHING_WRONG_HAPPENED, NETWORK_ERROR, PLEASE_TRY_AGAIN |
+| `.../toolbars/AppToolbarTitle.kt` | Standard top bar with back + search icon buttons |
+| `.../toolbars/CustomAppToolbar.kt` | Slot-based top bar (composable title, not string) |
+| `.../toolbars/AnimatedAppToolbar.kt` | Wraps any toolbar in expand/shrink animation (200ms delay, 500ms duration) |
+| `.../toolbars/NavigationBottomBar.kt` | 2-tab bar: Movies (index 0) + Favorite (index 1) |
+| `.../loaders/BubbleLoader.kt` | Custom 3-bubble Canvas animation loader |
+| `.../icons/BackNavigationIcon.kt` | Auto-mirrored back arrow (RTL support) |
+| `.../icons/SearchNavigationIcon.kt` | Search icon button |
+| `.../buttons/DeleteButton.kt` | Trash icon button |
+| `.../images/EmptyState.kt` | Sad emoji + "No movie here" centered column |
+
 ## Internal Dependencies
 - **None** — LEAF module, no project module dependencies (enforced by Popcorn Guineapig `NoDependencyRule`)
 
@@ -44,3 +112,5 @@ Shared UI module — provides the design tokens (colors, typography), reusable c
 - `BubbleLoader` uses raw `Canvas` drawing instead of Material 3 `CircularProgressIndicator`
 - `NavigationBottomBar` is fixed to two tabs — not extensible without code changes
 - No unit tests exist for any composable (no Compose UI testing setup)
+- **`CustomAppToolbar.kt` missing package declaration**: file starts directly with `import` statements — no `package com.gabrielbmoro.moviedb.desingsystem.toolbars` line. It compiles because the directory path implies the package, but Detekt should flag this.
+- **No custom `Typography` or `Shapes`**: `MovieDBAppTheme` sets only `colorScheme` on `MaterialTheme` — typography and shapes use Material3 defaults, which limits brand customization.

--- a/src/domain/README.md
+++ b/src/domain/README.md
@@ -1,0 +1,52 @@
+# domain
+
+## Purpose
+Core business logic module — defines the ubiquitous domain language, repository contracts, and use cases. This is a LEAF module with zero project module dependencies, following Clean Architecture principles.
+
+## Primary Responsibility
+- Define domain models that the entire app agrees on (`Movie`, `MovieDetail`, `VideoStream`, `HttpException`, `MovieListType`)
+- Declare `MoviesRepository` interface — the contract that `:data` implements
+- Implement business-logic use cases that orchestrate repository calls
+
+## Existing Functionalities
+- **Domain Models**
+  - `Movie` — core movie representation (id, title, rating, poster, overview, etc.)
+  - `MovieDetail` — full movie detail including genres, budget, homepage, production companies
+  - `MovieListType` — enum: `TOP_RATED`, `FAVORITE`, `POPULAR`, `UPCOMING` with `Int.convertToMovieListType()` extension
+  - `VideoStream` — YouTube video metadata (id, key, site, type)
+  - `HttpException` — custom exception with `statusCode`, `statusDescription`, `requestUrl`, `requestMethod`
+- **Repository Interface** (`MoviesRepository`) — 7 methods:
+  - `getMoviesFromFilter(filter, page)`, `getMovieDetail(movieId)`, `getVideoStreams(movieId)`, `searchMovieBy(query)`
+  - `getFavoriteMovies()`, `favorite(movie)`, `unFavorite(movieTitle)`, `checkIsAFavoriteMovie(movieTitle)`
+- **Use Cases**
+  - `FavoriteMovieUseCase` — toggle movie favorite status (wraps `repository.favorite()` / `repository.unFavorite()`)
+  - `GetMovieDetailsUseCase` — fetch movie details + video streams, filter for official YouTube trailers, attach `videoId` to `MovieDetail`
+  - `UseCase<Input, Output>` — generic interface with `suspend fun execute(input: Input): Output`
+- **DI** — `DomainModule` (`@ComponentScan("com.gabrielbmoro.moviedb.domain")`) uses Koin Annotations auto-discovery for `@Factory`-annotated use case implementations
+- **Tests** — use case tests with hand-written `FakeRepository`, model type tests
+
+## Internal Dependencies
+- **None** — LEAF module, no project module dependencies (enforced by Popcorn Guineapig `NoDependencyRule`)
+
+### Key External Libraries
+- Koin (annotations, core — for DI module compilation)
+- kotlinx-coroutines-core
+- kotlinx-serialization (implicitly through KMP stdlib)
+
+## External Dependencies (Consumers)
+- `:data` — implements `MoviesRepository` interface
+- `:feature-movies`, `:feature-details`, `:feature-search`, `:feature-wishlist` — all depend on domain models and use cases
+- `:composeApp` — aggregates `DomainModule` via Koin
+
+## Technical Notes
+- **Popcorn Guineapig rule**: `NoDependencyRule` — must have NO project module dependencies
+- Use cases follow the `UseCase<Input, Output>` pattern with a single `suspend fun execute(input)`
+- Koin Annotations with `@Module` + `@ComponentScan` auto-discovers `@Factory`-annotated implementations
+- `MovieListType` enum maps to TMDB API category strings via `MoviesHandler` in `feature-movies`
+- Tests use hand-written fakes (`FakeRepository`) per the project's no-mocking-frameworks standard
+
+## Technical Debts
+- `Movie` contains three `companion object` mock factory methods used only in tests — should live in test sources
+- `FavoriteMovieUseCase.Params` duplicates all `Movie` fields — consider using the domain model directly with `copy()`
+- `HttpException` extends `IllegalStateException` — should extend a more appropriate base or be replaced with a sealed result type
+- Only two use cases tested; the generic `UseCase` interface has no tests

--- a/src/domain/README.md
+++ b/src/domain/README.md
@@ -25,6 +25,63 @@ Core business logic module — defines the ubiquitous domain language, repositor
 - **DI** — `DomainModule` (`@ComponentScan("com.gabrielbmoro.moviedb.domain")`) uses Koin Annotations auto-discovery for `@Factory`-annotated use case implementations
 - **Tests** — use case tests with hand-written `FakeRepository`, model type tests
 
+## Entry Points
+
+| Entry Point | File | Signature | Role |
+|---|---|---|---|
+| Repository contract | `src/commonMain/kotlin/.../domain/MoviesRepository.kt` | `interface MoviesRepository` (7 suspend methods) | Contract boundary between domain and data layers |
+| Use case base | `src/commonMain/kotlin/.../usecases/UseCase.kt` | `interface UseCase<Input, Output>` | Generic use case contract with single `execute()` method |
+| Favorite use case | `src/commonMain/kotlin/.../usecases/FavoriteMovieUseCase.kt` | `interface FavoriteMovieUseCase : UseCase<Params, Unit>` | Toggle movie favorite status |
+| Details use case | `src/commonMain/kotlin/.../usecases/GetMovieDetailsUseCase.kt` | `interface GetMovieDetailsUseCase : UseCase<Params, MovieDetail>` | Fetch details + trailer enrichment |
+| Domain models | `src/commonMain/kotlin/.../domain/model/*.kt` (5 files) | `Movie`, `MovieDetail`, `VideoStream`, `HttpException`, `MovieListType` | Ubiquitous language types used across all layers |
+| DI module | `src/commonMain/kotlin/.../domain/di/DomainModule.kt` | `@ComponentScan @Module class DomainModule` | Koin Annotations auto-discovery of use case implementations |
+
+## Important Workflows
+
+### Use Case Execution Flow
+```
+Feature ViewModel instantiates a use case (e.g., GetMovieDetailsUseCase)
+  → Calls useCase.execute(Params(movieId))
+    → GetMovieDetailsUseCaseImpl (internal class in :domain)
+      → 1. repository.getMovieDetail(movieId) → MovieDetail
+      → 2. repository.getVideoStreams(movieId) → List<VideoStream>
+      → 3. Filter: first matching (site=="YouTube" && official && type=="Trailer")
+      → 4. Return movieDetail.copy(videoId = videoStream?.key)
+```
+
+### Favorite Toggle Workflow
+```
+Feature ViewModel calls FavoriteMovieUseCase
+  → FavoriteMovieUseCaseImpl.execute(Params(...))
+    → Constructs Movie from Params fields (with isFavorite = true)
+    → If toFavorite == true: repository.favorite(movie)
+    → If toFavorite == false: repository.unFavorite(movieTitle)
+      ⚠ Note: unfavorite uses movieTitle as unique key, not movieId
+```
+
+### Data Layer Contract (Dependency Inversion)
+```
+:domain defines interface MoviesRepository (7 suspend methods)
+  → :data module implements MoviesDataRepository : MoviesRepository (internal class)
+  → Feature modules depend on MoviesRepository interface (never on :data)
+  → Koin DI wires MoviesDataRepository for MoviesRepository at runtime
+```
+
+## Critical Files
+
+| File | Role |
+|---|---|
+| `.../domain/MoviesRepository.kt` | Repository interface — the domain/data boundary (Dependency Inversion) |
+| `.../usecases/UseCase.kt` | Base use case contract: `suspend fun execute(input: Input): Output` |
+| `.../usecases/FavoriteMovieUseCase.kt` | Favorite/unfavorite logic + `FavoriteMovieUseCaseImpl` (internal) |
+| `.../usecases/GetMovieDetailsUseCase.kt` | Detail fetch + YouTube trailer filter + `GetMovieDetailsUseCaseImpl` (internal) |
+| `.../model/Movie.kt` | Core movie domain model (10 fields) + 3 mock factory methods |
+| `.../model/MovieDetail.kt` | Extended movie detail (17 fields) with mutable `videoId` var |
+| `.../model/VideoStream.kt` | YouTube video metadata (id, key, site, type, official) |
+| `.../model/HttpException.kt` | Structured HTTP error model (status code, description, URL, method) |
+| `.../model/MovieListType.kt` | Filter category enum (TOP_RATED, FAVORITE, POPULAR, UPCOMING) + Int converter |
+| `.../di/DomainModule.kt` | Koin `@ComponentScan` module — auto-discovers use case implementations |
+
 ## Internal Dependencies
 - **None** — LEAF module, no project module dependencies (enforced by Popcorn Guineapig `NoDependencyRule`)
 
@@ -50,3 +107,6 @@ Core business logic module — defines the ubiquitous domain language, repositor
 - `FavoriteMovieUseCase.Params` duplicates all `Movie` fields — consider using the domain model directly with `copy()`
 - `HttpException` extends `IllegalStateException` — should extend a more appropriate base or be replaced with a sealed result type
 - Only two use cases tested; the generic `UseCase` interface has no tests
+- **Favorites keyed by title, not ID**: `MoviesRepository.unFavorite(movieTitle)` and `checkIsAFavoriteMovie(movieTitle)` use `movieTitle: String` as the lookup key. Movies with identical titles (e.g., remakes) collide. `Movie.id: Long` is the proper unique key.
+- **`MovieDetail` duplicates `Movie` fields**: `MovieDetail` re-declares `votesAverage`, `title`, `posterImageUrl`, `backdropImageUrl`, `overview`, `releaseDate`, `language`, `popularity` instead of composing from a `Movie` property. Changes to `Movie` must be mirrored manually in `MovieDetail`.
+- **`FavoriteMovieUseCaseImplTest` tests only the unfavorite path** — no test for `toFavorite = true` (the addition path).

--- a/src/feature-details/README.md
+++ b/src/feature-details/README.md
@@ -1,0 +1,48 @@
+# feature-details
+
+## Purpose
+Feature module — displays full movie details including backdrop, rating, favorite toggle, genres, production info, and video trailers. Accessed via deep link or card tap with a `movieId` argument.
+
+## Primary Responsibility
+- Render the movie detail screen (`DetailsScreen`) with a vertically scrollable layout
+- Fetch movie details + video streams via `GetMovieDetailsUseCase` + `MoviesRepository`
+- Persist/remove favorites via `FavoriteMovieUseCase`
+
+## Existing Functionalities
+- **DetailsScreen** — three rendering states: loading (`BubbleLoader`), error (`ErrorMessage`), content (scrollable `Column`)
+  - Content sections: `VideoPlayer` (backdrop, or YouTube iframe if video exists), `MovieDetailIndicator` (star rating + `Favorite` button), `GenresCard` (flow row of chips), `SectionTitle`/`SectionBody` pairs for overview, popularity, language, tagline, production companies, `TextUrl` for homepage
+  - `LaunchedEffect(movieId)` triggers `LoadMovieDetails` intent
+- **DetailsViewModel** — extends `BaseViewModel<DetailsUIState, DetailsUserIntent, UiEvent>`
+  - Intents: `LoadMovieDetails(movieId)`, `FavoriteMovie`, `HideVideo`
+  - `fetchMoviesDetails()` uses `runCatching { ... }.getOrNull()` for concurrent detail + favorite check
+  - `favoriteMovie()` toggles via use case (favorite → unfavorite, unfavorite → favorite)
+- **Model** — `DetailsUIState` (14 fields: loading, favorite, videoId, genres, errorMessage, etc.), `DetailsUserIntent` (HideVideo, FavoriteMovie, LoadMovieDetails)
+- **Widgets** — `Favorite` (heart icon toggle), `MovieDetailIndicator`, `GenresCard`, `SectionTitle`, `SectionBody`, `TextUrl` (clickable link), `ErrorMessage` (dino error image)
+- **DI** — `DetailsModule` (`lazyModule`): `viewModel { DetailsViewModel(...) }` (no separate handler/factory)
+- **Tests** — `DetailsViewModelTest` with hand-written `Fakes`
+
+## Internal Dependencies
+
+| Dependency | Relationship |
+|---|---|
+| `:domain` | `implementation` (MoviesRepository, FavoriteMovieUseCase, GetMovieDetailsUseCase, domain models) |
+| `:designsystem` | `implementation` (AsyncImage, FiveStars, BubbleLoader, BackNavigationIcon, AppToolbarTitle) |
+| `:platform` | `implementation` (BaseViewModel, VideoPlayer, LoggerHelper, navigation) |
+
+### Key External Libraries
+- Compose Multiplatform, kotlinx-collections-immutable, lifecycle-viewmodel-compose, Koin, Navigation Compose
+
+## External Dependencies (Consumers)
+- `:composeApp` — aggregates `featureDetailsModule` and renders `DetailsScreen` at the `Screen.Details/{movieId}` route
+
+## Technical Notes
+- `VideoPlayer` uses the `expect`/`actual` pattern from `platform` — embeds YouTube iframes in `WebView` (Android) or `WKWebView` (iOS)
+- Genre names are flattened from `MovieDetail.genres: List<String>`
+- `AnimatedAppToolbar` title appears only when user scrolls to top (animated visibility)
+- Back navigation is provided by `BackNavigationIcon` from designsystem
+
+## Technical Debts
+- **Silent error swallowing**: `fetchMoviesDetails()` uses `runCatching { ... }.getOrNull()` — errors are never logged and `onFailure` is a no-op. The `errorMessage` field in `DetailsUIState` is permanently `null`.
+- **Force unwraps (`!!`)**: `movieId!!` and `movieDetails!!` in the ViewModel crash the app if null (e.g., if state hasn't initialized before subsequent intents)
+- `DetailsUIState` has 14 fields with a manual `empty()` factory — consider sealed interface states (Loading/Error/Content) instead
+- No error handling for `FavoriteMovie` intent — if the toggle fails, UI silently reverts

--- a/src/feature-details/README.md
+++ b/src/feature-details/README.md
@@ -21,6 +21,72 @@ Feature module — displays full movie details including backdrop, rating, favor
 - **DI** — `DetailsModule` (`lazyModule`): `viewModel { DetailsViewModel(...) }` (no separate handler/factory)
 - **Tests** — `DetailsViewModelTest` with hand-written `Fakes`
 
+## Entry Points
+
+| Entry Point | File | Signature | Role |
+|---|---|---|---|
+| Screen | `src/commonMain/kotlin/.../ui/screens/details/DetailsScreen.kt` | `@Composable fun DetailsScreen(movieId: Long)` | Detail screen — loading/error/content states with scrollable layout |
+| ViewModel | `src/commonMain/kotlin/.../ui/screens/details/DetailsViewModel.kt` | `class DetailsViewModel : BaseViewModel<DetailsUIState, DetailsUserIntent, UiEvent>` | MVI ViewModel — fetches detail + video, toggles favorite |
+| Model | `src/commonMain/kotlin/.../ui/screens/details/Model.kt` | `data class DetailsUIState`, `sealed interface DetailsUserIntent` | MVI state (14 fields) + 3 intents |
+| DI | `src/commonMain/kotlin/.../di/DetailsModule.kt` | `val featureDetailsModule = lazyModule { }` | Koin lazy module — registers DetailsViewModel |
+
+## Important Workflows
+
+### Details Load Flow
+```
+LaunchedEffect(movieId) fires LoadMovieDetails(movieId) intent
+  → ViewModel.executeIntent → loadMovieDetails()
+    → updateState { isLoading = true }
+    → fetchMoviesDetails() — runCatching { getMovieDetailsUseCase.execute(Params(movieId)) }.getOrNull()
+      → Use case fetches MovieDetail + VideoStreams from repository
+      → Filters: first (site=="YouTube" && official && type=="Trailer") → videoId
+      → Returns MovieDetail.copy(videoId = videoKey) or null on failure
+    → If null: returns early (isLoading stays true — **permanent spinner bug**)
+    → isMovieFavorite(movieDetail.title) — checks via repository
+    → Updates state: movieDetail data, genres flattened, production companies joined, etc.
+    → updateState { isLoading = false }
+```
+
+### Favorite Toggle Flow
+```
+User taps Favorite(heart) icon → fires FavoriteMovie intent
+  → ViewModel.favoriteMovie() — NOT wrapped in runCatching
+    → movieId = state.value.movieDetails?.let { movieId!! }  ← force unwrap
+    → Checks current favorite status via repository.checkIsAFavoriteMovie(title)
+    → Constructs FavoriteMovieUseCase.Params from MovieDetail
+      → toFavorite = !currentFavoriteState (toggle)
+    → Calls favoriteMovieUseCase.execute(params)
+    → Re-checks favorite status after toggle
+    → Updates state: isFavorite = new status
+    ⚠ If repository or use case throws → coroutine silently killed (no runCatching)
+    ⚠ If movieId is null → crash (!! usage)
+```
+
+### Error States
+```
+Loading state: isLoading == true → DetailsScreenLoading (BubbleLoader)
+Error state: errorMessage != null → DetailsScreenError (ErrorMessage widget — static dino + "Sorry for that!")
+  ⚠ The actual errorMessage string value is never displayed; ErrorMessage widget ignores it
+Content state: !isLoading && errorMessage == null → DetailsScreenContent with all sections
+  ⚠ errorMessage is never populated by ViewModel — always null in practice
+```
+
+## Critical Files
+
+| File | Role |
+|---|---|
+| `.../ui/screens/details/DetailsScreen.kt` | Screen composable — 3-state rendering (loading/error/content) + toolbar animation |
+| `.../ui/screens/details/DetailsViewModel.kt` | ViewModel — detail fetch, video enrichment, favorite toggle |
+| `.../ui/screens/details/Model.kt` | MVI state (`DetailsUIState` 14 fields) + intents (`DetailsUserIntent`) |
+| `.../ui/widgets/Favorite.kt` | Heart icon toggle (filled red / outlined), circle-shaped, clickable |
+| `.../ui/widgets/MovieDetailIndicator.kt` | Row of Favorite button + FiveStars rating |
+| `.../ui/widgets/GenresCard.kt` | FlowRow of secondary-colored genre chips |
+| `.../ui/widgets/SectionTitle.kt` | `Text` wrapper with `titleMedium` style |
+| `.../ui/widgets/SectionBody.kt` | `Text` wrapper with `bodyMedium` style |
+| `.../ui/widgets/TextUrl.kt` | Clickable, italic, underlined URL that opens via `LocalUriHandler` |
+| `.../ui/widgets/ErrorMessage.kt` | Static error state — dino illustration + "Sorry for that!" title |
+| `.../di/DetailsModule.kt` | Koin lazy module — DI wiring for DetailsViewModel |
+
 ## Internal Dependencies
 
 | Dependency | Relationship |
@@ -46,3 +112,8 @@ Feature module — displays full movie details including backdrop, rating, favor
 - **Force unwraps (`!!`)**: `movieId!!` and `movieDetails!!` in the ViewModel crash the app if null (e.g., if state hasn't initialized before subsequent intents)
 - `DetailsUIState` has 14 fields with a manual `empty()` factory — consider sealed interface states (Loading/Error/Content) instead
 - No error handling for `FavoriteMovie` intent — if the toggle fails, UI silently reverts
+- **Permanent loading spinner bug**: `loadMovieDetails()` returns early when `fetchMoviesDetails()` returns null, but never sets `isLoading = false`. If the API call fails, the screen stays on the loading spinner forever.
+- **`favoriteMovie()` has no `runCatching` wrapper** — calls `favoriteMovieUseCase.execute()` unprotected. Any exception kills the coroutine with no user feedback.
+- **`SideEffect { println(...) }` debug artifact** in `DetailsScreen.kt` — prints UI state to stdout on every recomposition. Should use `LoggerHelper` or be removed.
+- **`Color.Red` hardcoded** in `Favorite.kt` widget — not theme-aware; won't adapt to dark/light mode correctly.
+- **`ErrorMessage` widget ignores the actual error message** — displays a static illustration and title regardless of what `errorMessage: String?` contains.

--- a/src/feature-movies/README.md
+++ b/src/feature-movies/README.md
@@ -20,6 +20,66 @@ Feature module — displays a paginated, filterable movie grid as the app's home
 - **DI** — `MoviesModule` (`lazyModule`): `factory { MoviesHandler(...) }`, `viewModel { MoviesViewModel(...) }`
 - **Tests** — `MoviesHandlerTest`, `MoviesViewModelTest` with hand-written `FakeRepository` and `FakeLogger`
 
+## Entry Points
+
+| Entry Point | File | Signature | Role |
+|---|---|---|---|
+| Screen | `src/commonMain/kotlin/.../ui/screens/movies/MoviesScreen.kt` | `@Composable fun MoviesScreen()` | Home screen — Scaffold with AnimatedAppToolbar + staggered grid + bottom bar |
+| ViewModel | `src/commonMain/kotlin/.../ui/screens/movies/MoviesViewModel.kt` | `class MoviesViewModel : BaseViewModel<MoviesState, MoviesIntent, UiEvent>, PagingController by SimplePaging()` | MVI ViewModel — handles setup, pagination, filter changes |
+| Handler | `src/commonMain/kotlin/.../components/MoviesHandler.kt` | `class MoviesHandler(repository: MoviesRepository)` | Use-case bridge: FilterType enum → TMDB API category strings |
+| Model | `src/commonMain/kotlin/.../ui/screens/movies/Model.kt` | `data class MoviesState`, `sealed interface MoviesIntent`, `data class MovieCardInfo` | MVI state/intent definitions + UI model |
+| DI | `src/commonMain/kotlin/.../di/MoviesModule.kt` | `val featureMoviesModule = lazyModule { }` | Koin lazy module — registers MoviesHandler + MoviesViewModel |
+
+## Important Workflows
+
+### Infinite Scroll Pagination
+```
+MoviesScreen renders MoviesList → LazyVerticalStaggeredGrid
+  → LaunchedEffect(canScrollForward): if (!canScrollForward) onRequestMore()
+    → ViewModel fires MoviesIntent.RequestMoreMovies
+      → PagingController.requestNextPage() → currentPage increments
+      → collectLatest(currentPage) triggers:
+        → MoviesHandler.getMoviesFromFilter(filter, page)
+          → translates FilterType to API string ("popular", "top_rated", "upcoming", "now_playing")
+          → Calls MoviesRepository.getMoviesFromFilter(apiString, page)
+        → Maps List<Movie> → List<MovieCardInfo>
+        → addAllDistinctly() — deduplicates by movieId, appends to existing list
+        → Updates MoviesState.movieCardInfos
+```
+
+### Filter Change Flow
+```
+User taps FilterChip in FilterMenu → fires SelectFilterMenuItem intent
+  → ViewModel cancels previous pagination coroutine job
+  → resetPaging() → currentPage resets to 1
+  → updateAccordingToFilterType() → toggles selected state on FilterMenuItems
+  → Updates state with selected filter + cleared movie list
+  → collectLatest(currentPage) triggers fresh fetch for page 1 with new filter
+```
+
+### Error → Retry Flow
+```
+API call throws exception → BaseViewModel.launchIo routes to onFailure()
+  → onFailure() maps throwable to ErrorInfo:
+    - HttpException → ErrorInfo.SOMETHING_WRONG_HAPPENED
+    - Other → ErrorInfo.NETWORK_ERROR
+  → MoviesScreen shows ErrorScreen(errorInfo, onRetry = { Setup intent })
+  → User taps Retry → fires MoviesIntent.Setup → full state reset + fresh fetch
+```
+
+## Critical Files
+
+| File | Role |
+|---|---|
+| `.../ui/screens/movies/MoviesScreen.kt` | Screen composable — Scaffold, toolbar animation, error/retry, scroll-to-top |
+| `.../ui/screens/movies/MoviesViewModel.kt` | ViewModel — pagination, filter switching, state deduplication, error mapping |
+| `.../ui/screens/movies/Model.kt` | MVI state (`MoviesState`), intents (`MoviesIntent`), UI models (`FilterMenuItem`, `FilterType`, `MovieCardInfo`) |
+| `.../ui/screens/movies/MoviesIntent.kt` | Intent sealed interface: `Setup`, `RequestMoreMovies`, `SelectFilterMenuItem` |
+| `.../components/MoviesHandler.kt` | Use-case bridge — FilterType → TMDB API category string mapping |
+| `.../ui/widgets/FilterMenu.kt` | `FilterMenu` — horizontal `LazyRow` of Material3 `FilterChip` items |
+| `.../ui/widgets/MoviesList.kt` | `MoviesList` — `LazyVerticalStaggeredGrid` (2 cols) with `canScrollForward` pagination trigger |
+| `.../di/MoviesModule.kt` | Koin lazy module — DI wiring for handler + viewModel |
+
 ## Internal Dependencies
 
 | Dependency | Relationship |
@@ -46,3 +106,6 @@ Feature module — displays a paginated, filterable movie grid as the app's home
 - `MoviesHandler` is injected as a `@Factory` but could be `@Single` (stateless)
 - No debounce on filter switching — rapid taps trigger multiple resets
 - Error handling only distinguishes `HttpException` types; other exceptions fall through without user-visible messages
+- **`MoviesHandler.kt` has no package declaration** — lives in root/default package despite being in directory `feature/movies/components/`. Imported as `import MoviesHandler` throughout the module.
+- **`!!` on nullable state** in `MoviesScreen.kt` line 99: `uiState.errorInfo!!` after null check — violates project convention.
+- **Inconsistent test imports**: test files import `LoggerHelper` as `com.gabrielbmoro.moviedb.logging.LoggerHelper` instead of the correct `com.gabrielbmoro.moviedb.platform.logging.LoggerHelper`.

--- a/src/feature-movies/README.md
+++ b/src/feature-movies/README.md
@@ -1,0 +1,48 @@
+# feature-movies
+
+## Purpose
+Feature module — displays a paginated, filterable movie grid as the app's home screen. Users browse movies by category (`Popular`, `Top Rated`, `Upcoming`, `Now Playing`) with infinite scroll.
+
+## Primary Responsibility
+- Render the movie browsing screen (`MoviesScreen`) with a `LazyVerticalStaggeredGrid` (2 columns)
+- Provide category filter tabs (`FilterMenu`) and handle pagination via `PagingController`
+- Coordinate data fetching through `MoviesHandler` → `MoviesRepository`
+
+## Existing Functionalities
+- **MoviesScreen** — `Scaffold` with `AnimatedAppToolbar` (shows/hides on scroll), `FilterMenu` filter chips, `MoviesList` staggered grid, `NavigationBottomBar`, error handling via `ErrorScreen`
+- **MoviesViewModel** — extends `BaseViewModel<MoviesState, MoviesIntent, UiEvent>` + `PagingController` (`SimplePaging`)
+  - Intents: `Setup`, `RequestMoreMovies`, `SelectFilterMenuItem`
+  - Pagination via `currentPage.collectLatest { ... }`
+  - Error mapping: `HttpException` → `ErrorInfo.SOMETHING_WRONG_HAPPENED` or `NETWORK_ERROR`
+  - Maintains `ImmutableList<MovieCardInfo>` with deduplication on page append
+- **MoviesHandler** — bridges filter types to TMDB API category strings (`popular`, `top_rated`, `upcoming`, `now_playing`) and delegates to `MoviesRepository`
+- **Model** — `MoviesState` (movies, filters, loading, error), `FilterMenuItem`, `FilterType` enum, `MovieCardInfo` (movieId, title, posterUrl)
+- **DI** — `MoviesModule` (`lazyModule`): `factory { MoviesHandler(...) }`, `viewModel { MoviesViewModel(...) }`
+- **Tests** — `MoviesHandlerTest`, `MoviesViewModelTest` with hand-written `FakeRepository` and `FakeLogger`
+
+## Internal Dependencies
+
+| Dependency | Relationship |
+|---|---|
+| `:domain` | `implementation` (MoviesRepository, domain models) |
+| `:designsystem` | `implementation` (MovieCard, AppToolbarTitle, NavigationBottomBar, FiveStars, ErrorScreen, BubbleLoader, AsyncImage) |
+| `:platform` | `implementation` (BaseViewModel, PagingController, LoggerHelper, navigation) |
+
+### Key External Libraries
+- Compose Multiplatform, kotlinx-collections-immutable, lifecycle-viewmodel-compose, Koin, Navigation Compose
+
+## External Dependencies (Consumers)
+- `:composeApp` — aggregates `featureMoviesModule` and renders `MoviesScreen` at the `Screen.Movies` route
+
+## Technical Notes
+- Uses `LazyVerticalStaggeredGrid` (not `LazyVerticalGrid`) for a masonry-like layout
+- The `AnimatedAppToolbar` visibility is computed from `LazyStaggeredGridState.firstVisibleItemIndex`
+- `MovieCardInfo` is defined locally in `Model.kt` — a lightweight UI model separate from the domain `Movie`
+- Scroll-to-top helper `LazyStaggeredGridState.scrollToInit()` is an extension function defined in the screen file
+- Filter selection triggers `resetPaging()` to restart from page 1
+
+## Technical Debts
+- `MovieCardInfo` is duplicated across feature-movies, feature-search, and feature-wishlist — should be promoted to a shared module
+- `MoviesHandler` is injected as a `@Factory` but could be `@Single` (stateless)
+- No debounce on filter switching — rapid taps trigger multiple resets
+- Error handling only distinguishes `HttpException` types; other exceptions fall through without user-visible messages

--- a/src/feature-search/README.md
+++ b/src/feature-search/README.md
@@ -20,6 +20,65 @@ Feature module — provides debounced movie search with inline results. Supports
 - **DI** — `SearchMovieModule` (`lazyModule`): `viewModel { params -> SearchViewModel(query = params.get(), ...) }`
 - **Tests** — `SearchViewModelTest` with `FakeRepository`
 
+## Entry Points
+
+| Entry Point | File | Signature | Role |
+|---|---|---|---|
+| Screen | `src/commonMain/kotlin/.../ui/screens/search/SearchScreen.kt` | `@Composable fun SearchScreen(query: String?)` | Search screen — Scaffold with search input + results list + auto-focus |
+| ViewModel | `src/commonMain/kotlin/.../ui/screens/search/SearchViewModel.kt` | `class SearchViewModel : BaseViewModel<SearchUIState, SearchUserIntent, UiEvent>` | MVI ViewModel — debounced search via MutableSharedFlow |
+| Model | `src/commonMain/kotlin/.../ui/screens/search/Model.kt` | `data class SearchUIState`, `sealed interface SearchUserIntent` | MVI state (searchQuery, results) + 2 intents |
+| DI | `src/commonMain/kotlin/.../di/SearchMovieModule.kt` | `val featureSearchMovieModule = lazyModule { }` | Koin lazy module — registers SearchViewModel with query param |
+
+## Important Workflows
+
+### Debounced Search Flow
+```
+User types in SearchInputText
+  → TextField onValueChange fires SearchBy(TextFieldValue)
+    → ViewModel.executeIntent:
+      1. Updates state: searchQuery = new TextFieldValue (immediate, for responsive typing)
+      2. Emits searchQuery.text to searchFlow: MutableSharedFlow<String>
+    → searchFlow.debounce(600ms) delays emission to avoid API spam
+    → collectLatest { query ->
+        call repository.searchMovieBy(query)  ⚠ NOT wrapped in runCatching
+        → Map List<Movie> → List<MovieCardInfo>
+        → Update state: results = mapped list
+      }
+
+User clears search field (taps X icon) → fires ClearSearchField intent
+  → ViewModel updates state: searchQuery = TextFieldValue(""), results = emptyList()
+```
+
+### Deep Link Search Flow
+```
+Rinku deep link: movie://search?query=batman
+  → DeeplinkEffect (in :composeApp) extracts query="batman"
+  → Navigates to SearchScreen(query = "batman")
+  → SearchScreen passes query to ViewModel via Koin parametersOf(query)
+  → ViewModel.init: seedSearchField(query) — sets initial TextFieldValue
+  → (No automatic search trigger — user must type to initiate API call)
+```
+
+### Keyboard Auto-Focus Sequence
+```
+SearchScreen composition:
+  → val focusRequester = remember { FocusRequester() }
+  → LaunchedEffect(Unit) { delay(500); focusRequester.requestFocus() }
+  → SearchInputText receives focusRequester → TextField gains focus → keyboard opens
+  → 500ms delay allows screen transition animation to complete before focus grab
+```
+
+## Critical Files
+
+| File | Role |
+|---|---|
+| `.../ui/screens/search/SearchScreen.kt` | Screen composable — Scaffold, toolbar search input, conditional results, auto-focus |
+| `.../ui/screens/search/SearchViewModel.kt` | ViewModel — debounced search via MutableSharedFlow, query seeding |
+| `.../ui/screens/search/Model.kt` | MVI state (`SearchUIState`) + intents (`SearchUserIntent`) |
+| `.../ui/widgets/SearchInputText.kt` | Material3 TextField with TextFieldValue + close icon trail |
+| `.../ui/widgets/MoviesResult.kt` | LazyColumn of MovieCard items + `MovieCardInfo` data class |
+| `.../di/SearchMovieModule.kt` | Koin lazy module — DI wiring for SearchViewModel with query param |
+
 ## Internal Dependencies
 
 | Dependency | Relationship |
@@ -46,3 +105,7 @@ Feature module — provides debounced movie search with inline results. Supports
 - **`!!` on nullable state**: `SearchScreen` uses `uiState.value.results!!` which crashes if results is null at composition time.
 - **Inconsistent DI naming**: `SearchMovieModule` / `featureSearchMovieModule` vs other features' `*Module` / `feature*Module` pattern.
 - No empty-state UI when search returns zero results (just an empty list).
+- **Missing `runCatching` on API call**: `repository.searchMovieBy(query)` in the ViewModel's `collectLatest` block is not wrapped in `runCatching`. Any API exception kills the coroutine.
+- **Missing `LoggerHelper` injection**: The ViewModel does not inject `LoggerHelper`, making it impossible to log errors even if `onFailure` were implemented.
+- **Test package naming inconsistency**: Production code uses `com.gabrielbmoro.moviedb.search.*`, but test code uses `com.gabrielbmoro.moviedb.feature.search.*`. These are in different source sets (commonMain vs commonTest) so they compile, but are inconsistent.
+- **Only 1 test case** (`ClearSearchField`) — no tests for debounced search, API results mapping, or pre-populated query flow.

--- a/src/feature-search/README.md
+++ b/src/feature-search/README.md
@@ -1,0 +1,48 @@
+# feature-search
+
+## Purpose
+Feature module — provides debounced movie search with inline results. Supports deep-linked queries and auto-focuses the search field on entry.
+
+## Primary Responsibility
+- Render the search screen (`SearchScreen`) with a text input and results list
+- Debounce user input (600ms) before triggering API searches
+- Display results as a scrollable `LazyColumn` of `MovieCard` items
+
+## Existing Functionalities
+- **SearchScreen** — `Scaffold` with `CustomAppToolbar` containing `SearchInputText`, auto-focuses keyboard with 500ms delay via `LaunchedEffect`
+  - Passes optional `query: String?` parameter (from deep link or navigation), forwarded to ViewModel via Koin `parametersOf`
+- **SearchViewModel** — extends `BaseViewModel<SearchUIState, SearchUserIntent, UiEvent>`
+  - Intents: `SearchBy(TextFieldValue)`, `ClearSearchField`
+  - Debounce via `MutableSharedFlow<String>` + `debounce(600ms)` before calling `repository.searchMovieBy()`
+  - Maps `Movie` → `MovieCardInfo` for the UI
+- **Model** — `SearchUIState` (searchQuery, results), `SearchUserIntent`
+- **Widgets** — `SearchInputText` (TextField with clear X icon), `MoviesResult` (LazyColumn of MovieCard items, also defines a local `MovieCardInfo` data class)
+- **DI** — `SearchMovieModule` (`lazyModule`): `viewModel { params -> SearchViewModel(query = params.get(), ...) }`
+- **Tests** — `SearchViewModelTest` with `FakeRepository`
+
+## Internal Dependencies
+
+| Dependency | Relationship |
+|---|---|
+| `:domain` | `implementation` (MoviesRepository, domain models) |
+| `:designsystem` | `implementation` (MovieCard, CustomAppToolbar, BackNavigationIcon, BubbleLoader) |
+| `:platform` | `implementation` (BaseViewModel, LoggerHelper, navigation) |
+
+### Key External Libraries
+- Compose Multiplatform, kotlinx-collections-immutable, lifecycle-viewmodel-compose, Koin, Navigation Compose
+
+## External Dependencies (Consumers)
+- `:composeApp` — aggregates `featureSearchMovieModule` and renders `SearchScreen` at the `Screen.Search?query=` route
+
+## Technical Notes
+- The debounce is implemented with `MutableSharedFlow<String>` + `debounce(600)` — this is an in-coroutine debounce, not Compose-side
+- Search input uses `TextFieldValue` (not plain `String`) for composition-aware cursor handling
+- The keyboard auto-focus uses `FocusRequester` with a `delay(500)` to allow animation to complete
+
+## Technical Debts
+- **Wrong package name**: `com.gabrielbmoro.moviedb.search` — should be `com.gabrielbmoro.moviedb.feature.search` per project conventions. All source files and imports are affected.
+- **`onFailure` is a no-op**: search failures are silently ignored — no error state, no user feedback. `SearchUIState` has no `errorMessage` field.
+- **Duplicate `MovieCardInfo`**: defined locally in `MoviesResult.kt` but also exists in `feature-movies/Model.kt` and `feature-wishlist/MovieList.kt`. Promote to a shared module.
+- **`!!` on nullable state**: `SearchScreen` uses `uiState.value.results!!` which crashes if results is null at composition time.
+- **Inconsistent DI naming**: `SearchMovieModule` / `featureSearchMovieModule` vs other features' `*Module` / `feature*Module` pattern.
+- No empty-state UI when search returns zero results (just an empty list).

--- a/src/feature-wishlist/README.md
+++ b/src/feature-wishlist/README.md
@@ -28,6 +28,89 @@ Feature module — displays the user's favorite (wishlist) movies with swipe-to-
 - **DI** — `featureWishlistModule` (`lazyModule`): `viewModel { WishlistViewModel(repository = get(), favoriteMovieUseCase = get(), ioCoroutinesDispatcher = Dispatchers.IO) }`
 - **Tests** — `WishlistViewModelTest` with hand-written `FakeRepository` and `FakeFavoriteMovieUseCase`; tests cover prepare-to-delete, load movies, and end-to-end delete flow
 
+## Entry Points
+
+| Entry Point | File | Signature | Role |
+|---|---|---|---|
+| Screen | `src/commonMain/kotlin/.../ui/screens/wishlist/WishlistScreen.kt` | `@Composable fun WishlistScreen()` | Wishlist screen — Scaffold with toolbar + LazyColumn + bottom bar + Snackbar |
+| ViewModel | `src/commonMain/kotlin/.../ui/screens/wishlist/WishlistViewModel.kt` | `class WishlistViewModel : BaseViewModel<WishlistUIState, WishlistUserIntent, WishlistUiEvent>` | MVI ViewModel — load favorites, two-step delete, event emission |
+| Model | `src/commonMain/kotlin/.../ui/screens/wishlist/Model.kt` | `data class WishlistUIState`, `sealed interface WishlistUserIntent`, `sealed class WishlistUiEvent` | MVI state + 4 intents + 1 one-shot event |
+| DI | `src/commonMain/kotlin/.../di/WishlistModule.kt` | `val featureWishlistModule = lazyModule { }` | Koin lazy module — registers WishlistViewModel |
+
+## Important Workflows
+
+### Favorites Load Flow
+```
+WishlistScreen composes → LaunchedEffect(Unit) fires LoadMovies intent
+  → ViewModel.handleLoadMovies()
+    → repository.getFavoriteMovies()  ⚠ NOT wrapped in runCatching
+    → Maps List<Movie> → List<MovieCardInfo> via toMovieCardInfo()
+    → Updates state: favoriteMovies = mapped list, isLoading = false
+  → Screen renders one of three states:
+    - isLoading: BubbleLoader centered
+    - favoriteMovies == null: EmptyState (sad emoji + "No movie here")
+    - favoriteMovies non-null non-empty: MovieList (LazyColumn of MovieCards)
+```
+
+### Two-Step Delete Flow
+```
+Step 1: User taps delete icon on a MovieCard
+  → fires PrepareToDeleteMovie(movie) intent
+  → ViewModel.handlePrepareToDeleteMovie()
+    → Stores movie in _movieToBeDeleted field (outside MVI state)
+    → Sets state: isDeleteAlertDialogVisible = true
+  → Screen shows DeleteConfirmationDialog AlertDialog
+    → Title: "Delete Movie?", Body: deletion confirmation message
+    → Positive button: "Delete", Negative button: "Cancel"
+
+Step 2a: User confirms deletion (taps "Delete")
+  → fires DeleteMovie intent
+  → ViewModel.handleDeleteMovie()
+    → favoriteMovieUseCase.execute(Params(toFavorite = false, ...))  ⚠ NOT wrapped in runCatching
+    → Reloads favorite movies (handleLoadMovies)
+    → Fires one-shot event: ShowSuccessfulDeleteMessage
+    → Clears _movieToBeDeleted
+    → Hides dialog: isDeleteAlertDialogVisible = false
+
+Step 2b: User cancels (taps "Cancel")
+  → fires HideConfirmDeleteDialog intent
+  → ViewModel.hideConfirmDeleteDialog(): sets isDeleteAlertDialogVisible = false
+```
+
+### Snackbar Event Flow
+```
+DeleteMovie intent → ViewModel.handleDeleteMovie()
+  → fireEvent(WishlistUiEvent.ShowSuccessfulDeleteMessage)
+  → Screen's LaunchedEffect collects uiEvent flow:
+    LaunchedEffect(Unit) {
+      viewModel.uiEvent.collect { event ->
+        when (event) {
+          is WishlistUiEvent.ShowSuccessfulDeleteMessage ->
+            snackbarHostState.showSnackbar("Movie deleted successfully")
+        }
+      }
+    }
+```
+
+### Bottom Bar Double-Tap Scroll-to-Top
+```
+User taps Favorite tab on NavigationBottomBar while already on Wishlist screen
+  → navigator.navigateToMovies() is NOT called (screen detects it's already on Wishlist)
+  → Detects: currentTab != MoviesTabIndex
+  → Calls lazyListState.scrollToItem(0) — scrolls list to top
+```
+
+## Critical Files
+
+| File | Role |
+|---|---|
+| `.../ui/screens/wishlist/WishlistScreen.kt` | Screen composable — 3-state rendering, Snackbar, bottom bar fast-tap |
+| `.../ui/screens/wishlist/WishlistViewModel.kt` | ViewModel — favorites load, two-step delete, one-shot events |
+| `.../ui/screens/wishlist/Model.kt` | MVI state (`WishlistUIState`), intents (`WishlistUserIntent`), events (`WishlistUiEvent`) |
+| `.../ui/widgets/MovieList.kt` | LazyColumn of MovieCards with delete enabled + `MovieCardInfo` data class |
+| `.../ui/widgets/DeleteConfirmationDialog.kt` | Material3 AlertDialog — title, body, confirm/cancel actions |
+| `.../di/WishlistModule.kt` | Koin lazy module — DI wiring for WishlistViewModel |
+
 ## Internal Dependencies
 
 | Dependency | Relationship |
@@ -53,3 +136,7 @@ Feature module — displays the user's favorite (wishlist) movies with swipe-to-
 - **`!!` on nullable state**: `WishlistScreen` uses `uiState.value.favoriteMovies!!` which crashes if the list is null at composition time.
 - **Duplicate `MovieCardInfo`**: defined locally in `MovieList.kt` but also exists in `feature-movies/Model.kt` and `feature-search/MoviesResult.kt`. Promote to a shared module.
 - `_movieToBeDeleted` is stored outside MVI state as a regular `var` — a source-of-truth split that could lead to inconsistency if state restoration is needed.
+- **Missing `runCatching` on repository/useCase calls**: `handleLoadMovies()` calls `repository.getFavoriteMovies()` and `handleDeleteMovie()` calls `favoriteMovieUseCase.execute()` — neither is wrapped in `runCatching`. Any exception kills the coroutine.
+- **Missing `LoggerHelper` injection**: The ViewModel does not inject `LoggerHelper`, making it impossible to log errors even if `onFailure` were implemented.
+- **`areBarsVisible` dead field**: declared in `WishlistUIState` but never read by any composable in the module.
+- **`delete_fail_message` dead resource**: defined in `strings.xml` as "Something went wrong" but never referenced in any source file.

--- a/src/feature-wishlist/README.md
+++ b/src/feature-wishlist/README.md
@@ -1,0 +1,55 @@
+# feature-wishlist
+
+## Purpose
+Feature module — displays the user's favorite (wishlist) movies with swipe-to-delete and a confirmation dialog. Accessed via the bottom navigation bar's favorite tab.
+
+## Primary Responsibility
+- Render the wishlist screen (`WishlistScreen`) with a `LazyColumn` of `MovieCard` items
+- Load all favorite movies from `MoviesRepository.getFavoriteMovies()`
+- Support deletion of individual favorites via `FavoriteMovieUseCase` with a confirmation `AlertDialog`
+
+## Existing Functionalities
+- **WishlistScreen** — `Scaffold` with `AppToolbarTitle`, `NavigationBottomBar`, and `SnackbarHost`
+  - Three content states: loading (`BubbleLoader`), empty (`EmptyState`), and populated (`MovieList`)
+  - Collects `uiEvent` via `LaunchedEffect` — shows a snackbar on successful deletion
+  - `LaunchedEffect(Unit)` triggers `LoadMovies` intent on first composition
+  - Bottom bar double-tap on the active favorites tab scrolls the list to top
+- **WishlistViewModel** — extends `BaseViewModel<WishlistUIState, WishlistUserIntent, WishlistUiEvent>`
+  - Intents: `LoadMovies`, `PrepareToDeleteMovie(movie)`, `DeleteMovie`, `HideConfirmDeleteDialog`
+  - `handleLoadMovies()` — fetches favorites from repository, maps `Movie` → `MovieCardInfo`, updates state
+  - `handlePrepareToDeleteMovie()` — stores the target movie in `_movieToBeDeleted` and shows the dialog
+  - `handleDeleteMovie()` — calls `FavoriteMovieUseCase.execute(toFavorite = false)`, reloads list, fires `ShowSuccessfulDeleteMessage` event, hides dialog
+  - `handleHideConfirmDeleteDialog()` — sets `isDeleteAlertDialogVisible = false`
+  - `onCleared()` nullifies `_movieToBeDeleted`
+- **Model** — `WishlistUIState` (favoriteMovies, isLoading, areBarsVisible, isDeleteAlertDialogVisible), `WishlistUserIntent` (4 intents), `WishlistUiEvent` (ShowSuccessfulDeleteMessage)
+- **Widgets**
+  - `MovieList` — `LazyColumn` rendering `MovieCard` items with `enableDelete = true`; defines `MovieCardInfo` data class (`@Stable @Immutable`, fields: id, title, votesAverage, overview, posterImageUrl); items keyed by `id`
+  - `DeleteConfirmationDialog` — Material3 `AlertDialog` with localized title/body/confirm/dismiss text; visible controlled by `visible: Boolean` parameter
+- **DI** — `featureWishlistModule` (`lazyModule`): `viewModel { WishlistViewModel(repository = get(), favoriteMovieUseCase = get(), ioCoroutinesDispatcher = Dispatchers.IO) }`
+- **Tests** — `WishlistViewModelTest` with hand-written `FakeRepository` and `FakeFavoriteMovieUseCase`; tests cover prepare-to-delete, load movies, and end-to-end delete flow
+
+## Internal Dependencies
+
+| Dependency | Relationship |
+|---|---|
+| `:domain` | `implementation` (MoviesRepository, FavoriteMovieUseCase, domain models) |
+| `:designsystem` | `implementation` (MovieCard, AppToolbarTitle, NavigationBottomBar, BubbleLoader, EmptyState) |
+| `:platform` | `implementation` (BaseViewModel, LoggerHelper, navigation) |
+
+### Key External Libraries
+- Compose Multiplatform, kotlinx-collections-immutable, lifecycle-viewmodel-compose, Koin, Navigation Compose
+
+## External Dependencies (Consumers)
+- `:composeApp` — aggregates `featureWishlistModule` and renders `WishlistScreen` at the `Screen.Wishlist` route
+
+## Technical Notes
+- The delete flow involves two intents: `PrepareToDeleteMovie` (shows dialog) → `DeleteMovie` (executes deletion). This ensures the user confirms before removing a favorite.
+- `_movieToBeDeleted` is stored as a ViewModel field (outside MVI state) to bridge between prepare and delete intents.
+- `toMovieCardInfo()` maps `Movie` → `MovieCardInfo` locally in the ViewModel.
+- Bottom bar fast-tap on the current tab scrolls the `LazyColumn` to item 0 via `lazyListState.scrollToItem(0)`.
+
+## Technical Debts
+- **`onFailure` is a no-op**: errors during load or delete are silently ignored — no error state, no user feedback. `WishlistUIState` has no `errorMessage` field.
+- **`!!` on nullable state**: `WishlistScreen` uses `uiState.value.favoriteMovies!!` which crashes if the list is null at composition time.
+- **Duplicate `MovieCardInfo`**: defined locally in `MovieList.kt` but also exists in `feature-movies/Model.kt` and `feature-search/MoviesResult.kt`. Promote to a shared module.
+- `_movieToBeDeleted` is stored outside MVI state as a regular `var` — a source-of-truth split that could lead to inconsistency if state restoration is needed.

--- a/src/iosApp/README.md
+++ b/src/iosApp/README.md
@@ -1,0 +1,101 @@
+# iosApp
+
+## Purpose
+
+iOS application shell that wraps the shared Compose Multiplatform UI (`:composeApp` module) inside a native SwiftUI application. Serves as the iOS deployment artifact.
+
+## Primary Responsibility
+
+Platform entry point for iOS — bootstraps Koin dependency injection, builds the Kotlin Multiplatform framework via Gradle, and hosts the Compose UI tree inside a `UIViewControllerRepresentable`.
+
+## Existing Functionalities
+
+- **App Launch** (`iosAppApp.swift`) — `@main` entry point that initializes Koin via `KoinHelperKt.doInitKoin()` before the UI renders
+- **Compose Bridge** (`ContentView.swift`) — `ComposeView` struct implementing `UIViewControllerRepresentable` that calls `MainViewControllerKt.MainViewController()` to create the shared Compose UI
+- **Framework Build Integration** — Xcode build phase script executes `./gradlew :composeApp:embedAndSignAppleFrameworkForXcode` to compile the KMP framework before the Swift linker runs
+- **App Icon** — 12 icon variants across all required iPhone/iPad scales plus 1024x1024 App Store icon
+- **Edge-to-Edge** — `.ignoresSafeArea(.container)` and `.ignoresSafeArea(.keyboard)` for full-screen rendering (Compose handles insets internally)
+- **High Refresh Rate** — `CADisableMinimumFrameDurationOnPhone: true` in `Info.plist` enables ProMotion display support
+
+## Entry Points
+
+| Entry Point | File | Signature | Role |
+|---|---|---|---|
+| App launch | `iosApp/iosAppApp.swift` | `@main struct iosAppApp: App` | Application entry, Koin init |
+| Compose bridge | `iosApp/ContentView.swift` | `struct ComposeView: UIViewControllerRepresentable` | Wraps Compose UI in SwiftUI |
+| Content wrapper | `iosApp/ContentView.swift` | `struct ContentView: View` | Root SwiftUI View |
+| Build phase | `iosApp.xcodeproj/project.pbxproj` | Shell script build phase | Gradle framework compilation |
+
+## Important Workflows
+
+### App Launch Sequence
+```
+iosAppApp.init()
+  → KoinHelperKt.doInitKoin()           // Starts Koin DI container (shared code)
+    → movieDbApplication { }             // Registers dataModule, platformModule, DomainModule, all feature lazyModules
+  → ContentView.body
+    → ComposeView (UIViewControllerRepresentable)
+      → makeUIViewController(context:)
+        → MainViewControllerKt.MainViewController()   // Shared KMP function
+          → ComposeUIViewController { MovieDBAppTheme { RootApp() } }
+```
+
+### Build-Time Workflow
+```
+Xcode build triggers "Compile Kotlin" phase
+  → cd $SRCROOT/..
+  → ./gradlew :composeApp:embedAndSignAppleFrameworkForXcode
+    → Compiles composeApp KMP module for iosX64, iosArm64, iosSimulatorArm64
+    → Produces static framework at composeApp/build/xcode-frameworks/<config>/<sdk>/
+  → Framework linked into iOS app binary
+```
+
+Environment variable `OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED=YES` can be set to skip the Gradle build phase (useful when Kotlin code hasn't changed).
+
+## Critical Files
+
+| File | Role |
+|---|---|
+| `iosApp/iosAppApp.swift` | `@main` entry point, Koin initialization |
+| `iosApp/ContentView.swift` | SwiftUI wrapper for Compose UI via `UIViewControllerRepresentable` |
+| `iosApp/Info.plist` | Bundle configuration: display name, ProMotion support |
+| `iosApp/Assets.xcassets/AppIcon.appiconset/` | App icon assets (12 sizes) |
+| `iosApp.xcodeproj/project.pbxproj` | Xcode project: build phases, framework search paths, signing |
+
+## Internal Dependencies
+
+Depends on `:composeApp` — both as a Gradle project dependency (framework compilation) and as a Swift `import ComposeApp` in source files. The framework is embedded during the Xcode build phase.
+
+| Dependency | Type | Purpose |
+|---|---|---|
+| `:composeApp` | Framework dependency | Shared Compose UI (imported as `ComposeApp`) |
+
+## External Dependencies
+
+None beyond Apple platform SDKs (SwiftUI, UIKit, WebKit — the last via the shared KMP framework's `VideoPlayer`).
+
+## Related Modules
+
+- **`:composeApp`** — Provides `MainViewController` and `KoinHelper` (iOS source set) exposed to Swift via `MainViewControllerKt` and `KoinHelperKt`. The iOS app is the only consumer of this module's `iosMain` source set.
+- **`:platform`** — Provides `VideoPlayer` composable (expect/actual) whose iOS actual uses `WKWebView`, which is linked through the shared framework.
+
+## Technical Notes
+
+- **Framework type:** Static framework named `ComposeApp` (configured in `KotlinMultiPlatformExt.kt` using `ConfigurationKeys.APP_NAME`)
+- **Deployment target:** iOS 17.4
+- **Swift version:** 5.0
+- **Xcode object version:** 56 (compatible with Xcode 14.0 minimum)
+- **Bundle ID:** `com.gabrielbmoro.moviedb.iosApp` — distinct from Android's `com.gabrielbmoro.moviedb`
+- **Target devices:** iPhone + iPad (`TARGETED_DEVICE_FAMILY = "1,2"`)
+- **Build configurations:** Debug and Release (Default: Release)
+- **Signing:** Development team `P8ZZXHC5BB`; release signing managed through Xcode
+- **Koin initialization** happens in Swift (`iosAppApp.init()`) before any Compose code runs, ensuring DI is ready when `MainViewController()` creates the Compose tree
+- **No deep links** on iOS — the Rinku library and `DeeplinkEffect` composable are Android-only. iOS navigation relies solely on in-app interaction
+
+## Technical Debts
+
+1. **No README existed for this module** — documentation gap filled as of this writing
+2. **Hardcoded development team** (`P8ZZXHC5BB`) in Xcode project — should use CI-configured code signing for reproducible builds
+3. **No iOS-specific tests** — the entire iOS target is tested only indirectly through shared KMP tests
+4. **Build phase runs Gradle on every Xcode build** — `OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED` workaround is manual; consider adopting KMP's built-in framework embedding
+5. **Marketing version hardcoded to 1.0** — should be derived from CI/build pipeline, not committed in the project file

--- a/src/platform/README.md
+++ b/src/platform/README.md
@@ -23,6 +23,98 @@ Platform abstraction module — provides navigation infrastructure, MVI base cla
 - **Video Player** — `expect fun VideoPlayer(videoId, modifier)` composable, actual implementations using `WebView` (Android) and `WKWebView` (iOS) with YouTube iframe embeds
 - **Tests** — `SimplePagingTest` verifies reset and increment behavior
 
+## Entry Points
+
+| Entry Point | File | Signature | Role |
+|---|---|---|---|
+| MVI base | `src/commonMain/kotlin/.../viewmodel/BaseViewModel.kt` | `abstract class BaseViewModel<State: UiState, Intent: UserIntent, Event: UiEvent>` | MVI foundation — all feature ViewModels extend this |
+| MVI markers | `src/commonMain/kotlin/.../viewmodel/Models.kt` | `interface UiState`, `interface UiEvent`, `interface UserIntent` | Marker interfaces enforced by MVI type params |
+| Navigation routes | `src/commonMain/kotlin/.../navigation/Screen.kt` | `enum class Screen(route, firstSegment)` | Single source of truth for all navigation routes and deep link segments |
+| Nav extensions | `src/commonMain/kotlin/.../navigation/NavHostControllerExt.kt` | Extension functions on `NavHostController` | `navigateToDetails()`, `navigateToSearch()`, `navigateToWishlist()`, `navigateToMovies()` |
+| Graph builder | `src/commonMain/kotlin/.../navigation/NavHostGraphBuilderExt.kt` | Extension functions on `NavGraphBuilder` | `addMoviesScreen()`, `addMovieDetailsScreen()`, `addSearchScreen()`, `addWishlistScreen()` |
+| Nav controller | `src/commonMain/kotlin/.../LocalNavController.kt` | `val LocalNavController = compositionLocalOf<NavHostController>` | CompositionLocal for accessing nav controller from any composable |
+| Pagination | `src/commonMain/kotlin/.../paging/PagingController.kt` | `interface PagingController` + `class SimplePaging : PagingController` | Page counter with `requestNextPage()` / `resetPaging()` |
+| Logging | `src/commonMain/kotlin/.../logging/Logger.kt` | `interface LoggerHelper` + `internal class LoggerHelperImpl` | Kermit wrapper — `logDebug`, `logInfo`, `logError` |
+| Video player | `src/commonMain/kotlin/.../media/VideoPlayer.kt` | `expect fun VideoPlayer(videoId: String, modifier: Modifier)` | Cross-platform YouTube embed via WebView (Android) / WKWebView (iOS) |
+
+## Important Workflows
+
+### MVI Lifecycle (BaseViewModel)
+```
+Feature ViewModel extends BaseViewModel<State, Intent, Event>
+  → Constructor: requires CoroutineDispatcher for IO, calls super(ioDispatcher)
+    → uiState: StateFlow<State> = MutableStateFlow(defaultEmptyState()).stateIn(SharingStarted.Eagerly)
+    → uiEvent: SharedFlow<Event> = MutableSharedFlow()
+  
+Feature Screen calls viewModel.executeIntent(intent)
+  → ViewModel.executeIntent(intent) routes to private handler methods
+    → launchIo { ... }  ← wraps in runCatching via BaseViewModel
+      → runCatching { block() }
+      → Success: result returned normally
+      → CancellationException: rethrown (cooperative cancellation)
+      → Other throwable: routed to onFailure(throwable)
+
+Feature ViewModel updates state:
+  → updateState { currentState -> currentState.copy(field = newValue) }
+  → MutableStateFlow.update { } — atomic, thread-safe
+
+Feature ViewModel emits one-shot events:
+  → fireEvent(event)
+  → MutableSharedFlow.emit(event)
+  → Screen collects via LaunchedEffect { viewModel.uiEvent.collect { ... } }
+```
+
+### Pagination Flow
+```
+ViewModel delegates to PagingController by SimplePaging()
+  → currentPage: StateFlow<Int> starts at 1
+  → ViewModel.collectLatest(currentPage) { page -> fetchMovies(page); appendToState() }
+  → Screen detects scroll-to-end → fires RequestMoreMovies intent
+    → ViewModel calls pagingController.requestNextPage()
+      → currentPage increments to 2 → collectLatest triggers fetch for page 2
+  → Filter change fires SelectFilterMenuItem intent
+    → ViewModel calls pagingController.resetPaging()
+      → currentPage resets to 1 → collectLatest triggers fresh fetch for page 1
+```
+
+### Navigation Deep Link Routing
+```
+Screen enum maps:
+  - Screen.Movies → route="movies", firstSegment=null (start destination, not deep-linked)
+  - Screen.Search → route="Search?query={query}", firstSegment="search"
+  - Screen.Details → route="details?movieId={movieId}", firstSegment="movie"
+  - Screen.Wishlist → route="wishlist", firstSegment="favorite"
+
+Rinku deep link: movie://movie/123
+  → DeeplinkEffect (in :composeApp) matches "movie" → Screen.Details.firstSegment
+  → Extracts 123 as movieId from path
+  → Calls navController.navigateToDetails(123L)
+    → String.detailsRoute(123) → "details?movieId=123"
+    → navController.navigate("details?movieId=123")
+
+Rinku deep link: movie://favorite
+  → DeeplinkEffect matches "favorite" → Screen.Wishlist.firstSegment
+  → Calls navController.navigateToWishlist()
+    → navController.navigate("wishlist")
+```
+
+## Critical Files
+
+| File | Role |
+|---|---|
+| `.../viewmodel/BaseViewModel.kt` | MVI base class — StateFlow, SharedFlow, Intent dispatch, error handling |
+| `.../viewmodel/Models.kt` | MVI marker interfaces: `UiState`, `UserIntent`, `UiEvent` |
+| `.../navigation/Screen.kt` | Route enum — single source of truth for navigation + deep link paths |
+| `.../navigation/NavHostGraphBuilderExt.kt` | DSL extensions for building NavHost routes (composable registration) |
+| `.../navigation/NavHostControllerExt.kt` | Navigation action helpers (navigateTo*) + route string builders |
+| `.../LocalNavController.kt` | CompositionLocal — exposes NavHostController to composable tree |
+| `.../paging/PagingController.kt` | PagingController interface + SimplePaging implementation |
+| `.../logging/Logger.kt` | LoggerHelper interface + LoggerHelperImpl (Kermit wrapper) |
+| `.../media/VideoPlayer.kt` (common) | `expect` composable — YouTube iframe HTML generator |
+| `.../media/VideoPlayer.android.kt` | Android actual — WebView interop via `AndroidView` |
+| `.../media/VideoPlayer.ios.kt` | iOS actual — WKWebView interop via `UIKitView` |
+| `.../di/PlatformModule.kt` | Koin module — binds `LoggerHelper` to `LoggerHelperImpl` |
+
 ## Internal Dependencies
 - **None** — LEAF module, no project module dependencies (enforced by Popcorn Guineapig `NoDependencyRule`)
 
@@ -50,3 +142,5 @@ Platform abstraction module — provides navigation infrastructure, MVI base cla
 - `LoggerHelper.plant(baseClass)` takes `KClass<*>` but stores via `simpleName` — different classes with the same simple name will collide
 - `NavHostGraphBuilderExt` sanitizes arguments manually; consider using type-safe navigation with route classes
 - The `MOVIE_DB_DOMAIN` constant used in iframe HTML is from the `platform` module, not from a configuration source
+- **`BaseViewModel` has no tests in this module** — the MVI base is tested only indirectly through feature ViewModel tests. Direct tests for `launchIo` error routing and state flow behavior would improve confidence.
+- **iOS `VideoPlayer` creates an unused `WKWebViewConfiguration` instance** — `remember { WKWebViewConfiguration() }` assigns a local variable that is never used, since properties are set directly on `webView.configuration`.

--- a/src/platform/README.md
+++ b/src/platform/README.md
@@ -1,0 +1,52 @@
+# platform
+
+## Purpose
+Platform abstraction module — provides navigation infrastructure, MVI base classes, pagination controller, logging abstraction, and platform-specific video player. A LEAF module with no project dependencies.
+
+## Primary Responsibility
+- Define the navigation route enum (`Screen`) and Compose navigation helper extensions
+- Provide `BaseViewModel` as the MVI foundation for all feature ViewModels
+- Offer `SimplePaging` as a reusable pagination primitive
+- Abstract platform-specific concerns: logging (`LoggerHelper`) and video playback (`VideoPlayer`)
+
+## Existing Functionalities
+- **Navigation**
+  - `Screen` enum — `Movies`, `Details/{movieId}`, `Search?query=`, `Wishlist` with route constants
+  - `NavHostGraphBuilderExt.kt` — DSL extensions: `addMoviesScreen`, `addMovieDetailsScreen`, `addWishlistScreen`, `addSearchScreen` (with argument extraction)
+  - `NavHostControllerExt.kt` — navigation helper functions: `navigateToDetails(movieId)`, `navigateToMovies()`, `navigateToSearch(query)`, `navigateToWishlist()`
+  - `LocalNavController.kt` — `CompositionLocal<NavHostController>` for accessing the nav controller from any composable
+- **MVI Foundation**
+  - `BaseViewModel<State, Intent, Event>` — abstract class providing `StateFlow<State>`, `SharedFlow<Event>`, `executeIntent()`, `updateState()`, `fireEvent()`, `launchIo()` (with `runCatching` safety), `onFailure()` callback
+  - `Models.kt` — marker interfaces: `UiState`, `UserIntent`, `UiEvent`
+- **Pagination** — `PagingController` interface + `SimplePaging` implementation (starts at page 1, increments on `requestNextPage()`, resets with `resetPaging()`)
+- **Logging** — `LoggerHelper` interface + `LoggerHelperImpl` (Kermit wrapper with `logDebug`, `logInfo`, `logError`)
+- **Video Player** — `expect fun VideoPlayer(videoId, modifier)` composable, actual implementations using `WebView` (Android) and `WKWebView` (iOS) with YouTube iframe embeds
+- **Tests** — `SimplePagingTest` verifies reset and increment behavior
+
+## Internal Dependencies
+- **None** — LEAF module, no project module dependencies (enforced by Popcorn Guineapig `NoDependencyRule`)
+
+### Key External Libraries
+- Compose Multiplatform (ui, foundation, material3)
+- Jetpack Navigation Compose (navigation runtime, compose integration)
+- Koin (core, coroutines, compose, compose-viewmodel)
+- Kermit (logging)
+- kotlinx-coroutines-core
+- Android: Material (for `AndroidView` in VideoPlayer)
+
+## External Dependencies (Consumers)
+- `:composeApp` — depends on `platform` for `Screen` enum and `NavHostGraphBuilderExt`
+- `:feature-movies`, `:feature-details`, `:feature-search`, `:feature-wishlist` — all extend `BaseViewModel` and use `PagingController`, `LoggerHelper`, navigation helpers
+
+## Technical Notes
+- **Popcorn Guineapig rule**: `NoDependencyRule` — must have NO project module dependencies
+- `BaseViewModel.launchIo()` wraps all coroutine work in `runCatching`, rethrows `CancellationException`, and calls `onFailure(throwable)` for real exceptions
+- `SimplePaging.currentPage` is exposed as a `StateFlow<Int>` consumed via `collectLatest` in ViewModels for pagination
+- `VideoPlayer` uses `expect`/`actual` because Compose Multiplatform doesn't provide a built-in video player composable; the implementation embeds YouTube iframes in platform web views
+- `LocalNavController` must be provided at a higher composition level (done in `RootApp.kt` in `composeApp`)
+
+## Technical Debts
+- `VideoPlayer` embeds YouTube via raw HTML iframes — cannot play non-YouTube videos, no play/pause controls, no full-screen support
+- `LoggerHelper.plant(baseClass)` takes `KClass<*>` but stores via `simpleName` — different classes with the same simple name will collide
+- `NavHostGraphBuilderExt` sanitizes arguments manually; consider using type-safe navigation with route classes
+- The `MOVIE_DB_DOMAIN` constant used in iframe HTML is from the `platform` module, not from a configuration source


### PR DESCRIPTION
## Description

Adds comprehensive README.md documentation to every project module, covering purpose, responsibilities, existing functionalities, and architecture notes.

## Changes

- **New READMEs** — 12 new README.md files across all modules (`androidApp`, `build-logic`, `composeApp`, `data`, `designsystem`, `domain`, `feature-details`, `feature-movies`, `feature-search`, `feature-wishlist`, `iosApp`, `platform`) with purpose statements, responsibility overviews, and existing functionality lists
- **opencode.json** — Disable Kotzilla MCP from auto-starting on opencode session load

## Commits

- `fc067b4` Avoid start kotzilla mcp when opencode loads session + adding readme.md for each module
- `e2c51b3` update readmes