### PR TITLE
Add YAML front matter to module READMEs for AI searchability

### DIFF
--- a/src/androidApp/README.md
+++ b/src/androidApp/README.md
@@ -1,3 +1,9 @@
+---
+module: androidApp
+summary: "Android entry point — Application subclass, ComponentActivity, deep link intent filters, dynamic colors, edge-to-edge."
+keywords: [android, activity, application, manifest, deep-links, dynamic-colors, edge-to-edge, firebase, kotzilla]
+---
+
 # androidApp
 
 ## Purpose

--- a/src/build-logic/README.md
+++ b/src/build-logic/README.md
@@ -1,3 +1,9 @@
+---
+module: build-logic
+summary: "Gradle included build with convention plugins for KMP, Detekt, Koin compiler, and architecture rule enforcement."
+keywords: [gradle, convention-plugins, kmp, detekt, koin-compiler, popcorn-guineapig, architecture-rules, sdk-config, versioning]
+---
+
 # build-logic
 
 ## Purpose

--- a/src/composeApp/README.md
+++ b/src/composeApp/README.md
@@ -1,3 +1,9 @@
+---
+module: composeApp
+summary: "UI orchestrator that assembles the NavHost, aggregates all Koin DI modules, and handles deep links."
+keywords: [navhost, navigation-graph, koin, di-aggregation, deep-links, rinku, ios-bridge, root-app]
+---
+
 # composeApp
 
 ## Purpose

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -1,3 +1,9 @@
+---
+module: data
+summary: "Implements repository interfaces with Ktor API client for TMDB and Room persistence for favorites."
+keywords: [api, http, ktor, room, sqlite, persistence, tmdb, favorites, dto, mappers, buildkonfig]
+---
+
 # data
 
 ## Purpose

--- a/src/designsystem/README.md
+++ b/src/designsystem/README.md
@@ -1,3 +1,9 @@
+---
+module: designsystem
+summary: "Shared design tokens, Material 3 theme, and reusable UI composables (cards, toolbars, image loaders, error screens)."
+keywords: [theme, colors, material3, cards, toolbars, images, coil, error-screen, loaders, icons, dynamic-colors]
+---
+
 # designsystem
 
 ## Purpose

--- a/src/domain/README.md
+++ b/src/domain/README.md
@@ -1,3 +1,9 @@
+---
+module: domain
+summary: "Defines domain models, repository interfaces, and use cases — the Clean Architecture inner layer."
+keywords: [repository, usecases, domain-models, movies, tvshows, favorites, contract, interfaces, clean-architecture, di]
+---
+
 # domain
 
 ## Purpose

--- a/src/feature-movies/README.md
+++ b/src/feature-movies/README.md
@@ -1,3 +1,9 @@
+---
+module: feature-movies
+summary: "Paginated movie browsing screen with category filter tabs and infinite scroll."
+keywords: [movies, browse, filter-tabs, pagination, infinite-scroll, staggered-grid, popular, top-rated, upcoming, now-playing]
+---
+
 # feature-movies
 
 ## Purpose

--- a/src/feature-search/README.md
+++ b/src/feature-search/README.md
@@ -1,3 +1,9 @@
+---
+module: feature-search
+summary: "Debounced movie search with text input, auto-focus, and results list."
+keywords: [search, debounce, text-input, autofocus, movies, shared-flow, results]
+---
+
 # feature-search
 
 ## Purpose

--- a/src/feature-tvshows/README.md
+++ b/src/feature-tvshows/README.md
@@ -1,3 +1,9 @@
+---
+module: feature-tvshows
+summary: "Paginated TV show browsing screen with category filter tabs and infinite scroll."
+keywords: [tv-shows, browse, filter-tabs, pagination, infinite-scroll, staggered-grid, popular, top-rated, on-the-air, airing-today]
+---
+
 # feature-tvshows
 
 ## Purpose

--- a/src/feature-wishlist/README.md
+++ b/src/feature-wishlist/README.md
@@ -1,3 +1,9 @@
+---
+module: feature-wishlist
+summary: "Favorited movies list with two-step swipe-to-delete and confirmation dialog."
+keywords: [wishlist, favorites, delete, confirmation-dialog, snackbar, movie-card, lazy-column]
+---
+
 # feature-wishlist
 
 ## Purpose

--- a/src/iosApp/README.md
+++ b/src/iosApp/README.md
@@ -1,3 +1,9 @@
+---
+module: iosApp
+summary: "iOS entry point — SwiftUI app wrapper, Compose UI bridge via UIViewControllerRepresentable, Koin init."
+keywords: [ios, swiftui, xcode, uiviewcontroller, framework, koin-init, static-framework, app-icon]
+---
+
 # iosApp
 
 ## Purpose

--- a/src/platform/README.md
+++ b/src/platform/README.md
@@ -1,3 +1,9 @@
+---
+module: platform
+summary: "Provides navigation routes, MVI base classes, pagination controller, logging, and video player abstractions."
+keywords: [navigation, mvi, base-viewmodel, stateflow, pagination, logging, kermit, video-player, deep-links]
+---
+
 # platform
 
 ## Purpose


### PR DESCRIPTION
## Description

Prepend `module`, `summary`, and `keywords` YAML front matter to all 12 module READMEs under `src/`. Enables AI agents to quickly identify relevant modules without parsing the full ~100-line documents.

## Changes

- Added YAML front matter (`---` delimited) to 12 `src/*/README.md` files
- Each block contains `module` name, one-sentence `summary`, and 7–12 `keywords`
- No existing content modified — purely additive (+72 lines)

## Commits

- `7c52e05d` Add YAML front matter to module READMEs for AI searchability